### PR TITLE
Escape bash in passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Departure.configure do |config|
 end
 ```
 
-Unlike using `PERCONA_ARGS`, options provided with global configuration will be applied 
+Unlike using `PERCONA_ARGS`, options provided with global configuration will be applied
 every time sql command is executed via `pt-online-schema-change`.
- 
-Arguments provided in global configuration can be overwritten with `PERCONA_ARGS` env variable. 
+
+Arguments provided in global configuration can be overwritten with `PERCONA_ARGS` env variable.
 
 We recommend using this option with caution and only when you understand the consequences.
 
@@ -170,6 +170,12 @@ the system, with the apropriate arguments for the generated SQL.
 When an any error occurs, an `ActiveRecord::StatementInvalid` exception is
 raised and the migration is aborted, as all other ActiveRecord connection
 adapters.
+
+## Trouleshooting
+
+### Error creating new table: DBD::mysql::db do failed: Can't write; duplicate key in table (TABLE_NAME)
+There is a [https://bugs.launchpad.net/percona-toolkit/+bug/1498128](known bug) in percona-toolkit version 2.2.15
+that prevents schema changes when a table has constraints. You should upgrade to a version later than 2.2.17 to fix the issue.
 
 ## Development
 

--- a/lib/departure/connection_details.rb
+++ b/lib/departure/connection_details.rb
@@ -34,7 +34,7 @@ module Departure
     # @return [String]
     def password_argument
       if password.present?
-        %(--password "#{Shellwords.escape(password)}" )
+        %(--password #{Shellwords.escape(password)} )
       else
         ''
       end

--- a/lib/departure/connection_details.rb
+++ b/lib/departure/connection_details.rb
@@ -1,3 +1,4 @@
+require 'shellwords'
 module Departure
   # Holds the parameters of the DB connection and formats them to string
   class ConnectionDetails
@@ -33,7 +34,7 @@ module Departure
     # @return [String]
     def password_argument
       if password.present?
-        %(--password "#{password}" )
+        %(--password "#{Shellwords.escape(password)}" )
       else
         ''
       end

--- a/spec/departure/connection_details_spec.rb
+++ b/spec/departure/connection_details_spec.rb
@@ -63,6 +63,12 @@ describe Departure::ConnectionDetails do
       let(:env_var) { { PERCONA_DB_PASSWORD: 'password' } }
       it { is_expected.to include('--password "password"') }
     end
+
+    context 'when the password contains bash incompatible characters' do
+      let(:env_var) { {} }
+      let(:connection_data) { { password: '!#/PASSWORD!!!' } }
+      it { is_expected.to include('--password "\!\#/PASSWORD\!\!\!"') }
+    end
   end
 
   describe '#database' do

--- a/spec/departure/connection_details_spec.rb
+++ b/spec/departure/connection_details_spec.rb
@@ -61,13 +61,13 @@ describe Departure::ConnectionDetails do
 
     context 'when specifying PERCONA_DB_PASSWORD' do
       let(:env_var) { { PERCONA_DB_PASSWORD: 'password' } }
-      it { is_expected.to include('--password "password"') }
+      it { is_expected.to include('--password password') }
     end
 
     context 'when the password contains bash incompatible characters' do
       let(:env_var) { {} }
       let(:connection_data) { { password: '!#/PASSWORD!!!' } }
-      it { is_expected.to include('--password "\!\#/PASSWORD\!\!\!"') }
+      it { is_expected.to include('--password \!\#/PASSWORD\!\!\!') }
     end
   end
 


### PR DESCRIPTION
# WAT
This Fixes and issue that prevented the use of bash special characters in passwords.

# Escape
![](https://media2.giphy.com/media/Pl3hc2u2A2ktW/giphy.gif)