### PR TITLE
V5.0

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -8,8 +8,8 @@ require 'departure/version'
 Gem::Specification.new do |spec|
   spec.name          = 'departure'
   spec.version       = Departure::VERSION
-  spec.authors       = ['Ilya Zayats', 'Pau Pérez', 'Fran Casas', 'Jorge Morante', 'Enrico Stano', 'Adrian Serafin']
-  spec.email         = ['ilya.zayats@redbooth.com', 'pau.perez@redbooth.com', 'fran.casas@redbooth.com', 'jorge.morante@redbooth.com', 'adrian@softmad.pl']
+  spec.authors       = ['Ilya Zayats', 'Pau Pérez', 'Fran Casas', 'Jorge Morante', 'Enrico Stano', 'Adrian Serafin', 'Kirk Haines']
+  spec.email         = ['ilya.zayats@redbooth.com', 'pau.perez@redbooth.com', 'fran.casas@redbooth.com', 'jorge.morante@redbooth.com', 'adrian@softmad.pl', 'wyhaines@gmail.com']
 
   spec.summary       = %q(pt-online-schema-change runner for ActiveRecord migrations)
   spec.description   = %q(Execute your ActiveRecord migrations with Percona's pt-online-schema-change. Formerly known as Percona Migrator.)
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rails', '~> 4.2.0'
+  spec.add_runtime_dependency 'rails', '~> 5.1'
   spec.add_runtime_dependency 'mysql2', '~> 0.4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/departure.gemspec
+++ b/departure.gemspec
@@ -19,10 +19,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rails', '~> 5.1'
+  spec.add_runtime_dependency 'rails', '~> 5.0.6'
   spec.add_runtime_dependency 'mysql2', '~> 0.4.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
   spec.add_development_dependency 'rspec-its', '~> 1.2'

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -92,9 +92,11 @@ module ActiveRecord
         true
       end
 
+      # rubocop:disable Metrics/ParameterList
       def new_column(field, default, type_metadata, null, table_name, default_function, collation, comment)
         Column.new(field, default, type_metadata, null, table_name, default_function, collation, comment)
       end
+      # # rubocop:enable Metrics/ParameterList
 
       # Adds a new index to the table
       #

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -92,11 +92,11 @@ module ActiveRecord
         true
       end
 
-      # rubocop:disable Metrics/ParameterList
+      # rubocop:disable Metrics/ParameterLists
       def new_column(field, default, type_metadata, null, table_name, default_function, collation, comment)
         Column.new(field, default, type_metadata, null, table_name, default_function, collation, comment)
       end
-      # # rubocop:enable Metrics/ParameterList
+      # rubocop:enable Metrics/ParameterLists
 
       # Adds a new index to the table
       #

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -40,7 +40,8 @@ module ActiveRecord
 
   module ConnectionAdapters
     class DepartureAdapter < AbstractMysqlAdapter
-      class Column < AbstractMysqlAdapter::Column
+
+      class Column < ActiveRecord::ConnectionAdapters::MySQL::Column
         def adapter
           DepartureAdapter
         end
@@ -53,9 +54,9 @@ module ActiveRecord
       def_delegators :mysql_adapter, :last_inserted_id, :each_hash, :set_field_encoding
 
       def initialize(connection, _logger, connection_options, _config)
+        @mysql_adapter = connection_options[:mysql_adapter]
         super
         @prepared_statements = false
-        @mysql_adapter = connection_options[:mysql_adapter]
       end
 
       def exec_delete(sql, name, binds)
@@ -75,8 +76,9 @@ module ActiveRecord
 
       # Executes a SELECT query and returns an array of rows. Each row is an
       # array of field values.
-      def select_rows(sql, name = nil)
-        execute(sql, name).to_a
+
+      def select_rows(arel, name = nil, binds = [])
+        select_all(arel, name, binds).rows
       end
 
       # Executes a SELECT query and returns an array of record hashes with the
@@ -90,8 +92,8 @@ module ActiveRecord
         true
       end
 
-      def new_column(field, default, cast_type, sql_type = nil, null = true, collation = '', extra = '') # rubocop:disable Metrics/ParameterLists, Metrics/LineLength
-        Column.new(field, default, cast_type, sql_type, null, collation, strict_mode?, extra)
+      def new_column(field, default, type_metadata, null, table_name, default_function, collation, comment)
+        Column.new(field, default, type_metadata, null, table_name, default_function, collation, comment)
       end
 
       # Adds a new index to the table

--- a/lib/departure/version.rb
+++ b/lib/departure/version.rb
@@ -1,3 +1,3 @@
 module Departure
-  VERSION = '4.0.1'.freeze
+  VERSION = '5.0.1'.freeze
 end

--- a/lib/lhm/column_with_sql.rb
+++ b/lib/lhm/column_with_sql.rb
@@ -57,7 +57,6 @@ module Lhm
         name,
         default_value,
         cast_type,
-        definition,
         null_value
       )
     end

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -44,7 +44,11 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
     described_class.new(runner, logger, connection_options, config)
   end
 
+  let(:mysql_client) { double(:mysql_client) }
+
   before do
+    allow(mysql_client).to receive(:server_info).and_return({version: '5.7.19'})
+    allow(mysql_adapter).to receive(:raw_connection).and_return(mysql_client)
     allow(runner).to(
       receive(:execute).with('percona command').and_return(true)
     )
@@ -67,10 +71,13 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
     let(:type) { double(:type) }
     let(:null) { double(:null) }
     let(:collation) { double(:collation) }
+    let(:table_name) { double(:table_name) }
+    let(:default_function) { double(:default_function) }
+    let(:comment) { double(:comment) }
 
     it do
       expect(ActiveRecord::ConnectionAdapters::DepartureAdapter::Column).to receive(:new)
-      adapter.new_column(field, default, type, null, collation)
+      adapter.new_column(field, default, type, null, table_name, default_function, collation, comment)
     end
   end
 
@@ -202,7 +209,7 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
 
     let(:array_of_rows) { [%w[1 body], %w[2 body]] }
     let(:mysql2_result) do
-      instance_double(Mysql2::Result, to_a: array_of_rows)
+      instance_double(Mysql2::Result, to_a: array_of_rows, fields: [:id, :body])
     end
 
     before do

--- a/spec/fixtures/migrate/10_data_migration_with_find_each.rb
+++ b/spec/fixtures/migrate/10_data_migration_with_find_each.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithFindEach < ActiveRecord::Migration
+class DataMigrationWithFindEach < ActiveRecord::Migration[5.1]
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/fixtures/migrate/10_data_migration_with_find_each.rb
+++ b/spec/fixtures/migrate/10_data_migration_with_find_each.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithFindEach < ActiveRecord::Migration[5.1]
+class DataMigrationWithFindEach < ActiveRecord::Migration[5.0]
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/fixtures/migrate/11_data_migration_with_question_mark_interpolation.rb
+++ b/spec/fixtures/migrate/11_data_migration_with_question_mark_interpolation.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithQuestionMarkInterpolation < ActiveRecord::Migration
+class DataMigrationWithQuestionMarkInterpolation < ActiveRecord::Migration[5.1]
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/fixtures/migrate/11_data_migration_with_question_mark_interpolation.rb
+++ b/spec/fixtures/migrate/11_data_migration_with_question_mark_interpolation.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithQuestionMarkInterpolation < ActiveRecord::Migration[5.1]
+class DataMigrationWithQuestionMarkInterpolation < ActiveRecord::Migration[5.0]
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/fixtures/migrate/12_data_migration_with_named_binds.rb
+++ b/spec/fixtures/migrate/12_data_migration_with_named_binds.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithNamedBinds < ActiveRecord::Migration
+class DataMigrationWithNamedBinds < ActiveRecord::Migration[5.1]
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/fixtures/migrate/12_data_migration_with_named_binds.rb
+++ b/spec/fixtures/migrate/12_data_migration_with_named_binds.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithNamedBinds < ActiveRecord::Migration[5.1]
+class DataMigrationWithNamedBinds < ActiveRecord::Migration[5.0]
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/fixtures/migrate/13_rename_index_on_comments.rb
+++ b/spec/fixtures/migrate/13_rename_index_on_comments.rb
@@ -1,4 +1,4 @@
-class RenameIndexOnComments < ActiveRecord::Migration
+class RenameIndexOnComments < ActiveRecord::Migration[5.1]
   def change
     rename_index :comments, 'index_comments_on_some_id_field', 'new_index_comments_on_some_id_field'
   end

--- a/spec/fixtures/migrate/13_rename_index_on_comments.rb
+++ b/spec/fixtures/migrate/13_rename_index_on_comments.rb
@@ -1,4 +1,4 @@
-class RenameIndexOnComments < ActiveRecord::Migration[5.1]
+class RenameIndexOnComments < ActiveRecord::Migration[5.0]
   def change
     rename_index :comments, 'index_comments_on_some_id_field', 'new_index_comments_on_some_id_field'
   end

--- a/spec/fixtures/migrate/14_change_column_null_true.rb
+++ b/spec/fixtures/migrate/14_change_column_null_true.rb
@@ -1,4 +1,4 @@
-class ChangeColumnNullTrue < ActiveRecord::Migration
+class ChangeColumnNullTrue < ActiveRecord::Migration[5.1]
   def change
     change_column_null(:comments, :some_id_field, true)
   end

--- a/spec/fixtures/migrate/14_change_column_null_true.rb
+++ b/spec/fixtures/migrate/14_change_column_null_true.rb
@@ -1,4 +1,4 @@
-class ChangeColumnNullTrue < ActiveRecord::Migration[5.1]
+class ChangeColumnNullTrue < ActiveRecord::Migration[5.0]
   def change
     change_column_null(:comments, :some_id_field, true)
   end

--- a/spec/fixtures/migrate/15_change_column_null_false.rb
+++ b/spec/fixtures/migrate/15_change_column_null_false.rb
@@ -1,4 +1,4 @@
-class ChangeColumnNullFalse < ActiveRecord::Migration
+class ChangeColumnNullFalse < ActiveRecord::Migration[5.1]
   def change
     change_column_null(:comments, :some_id_field, false)
   end

--- a/spec/fixtures/migrate/15_change_column_null_false.rb
+++ b/spec/fixtures/migrate/15_change_column_null_false.rb
@@ -1,4 +1,4 @@
-class ChangeColumnNullFalse < ActiveRecord::Migration[5.1]
+class ChangeColumnNullFalse < ActiveRecord::Migration[5.0]
   def change
     change_column_null(:comments, :some_id_field, false)
   end

--- a/spec/fixtures/migrate/16_add_reference.rb
+++ b/spec/fixtures/migrate/16_add_reference.rb
@@ -1,4 +1,4 @@
-class AddReference < ActiveRecord::Migration
+class AddReference < ActiveRecord::Migration[5.1]
   def change
     add_reference(:comments, :user)
   end

--- a/spec/fixtures/migrate/16_add_reference.rb
+++ b/spec/fixtures/migrate/16_add_reference.rb
@@ -1,4 +1,4 @@
-class AddReference < ActiveRecord::Migration[5.1]
+class AddReference < ActiveRecord::Migration[5.0]
   def change
     add_reference(:comments, :user)
   end

--- a/spec/fixtures/migrate/17_add_polymorphic_reference.rb
+++ b/spec/fixtures/migrate/17_add_polymorphic_reference.rb
@@ -1,4 +1,4 @@
-class AddPolymorphicReference < ActiveRecord::Migration
+class AddPolymorphicReference < ActiveRecord::Migration[5.1]
   def change
     add_reference(:comments, :user, polymorphic: true)
   end

--- a/spec/fixtures/migrate/17_add_polymorphic_reference.rb
+++ b/spec/fixtures/migrate/17_add_polymorphic_reference.rb
@@ -1,4 +1,4 @@
-class AddPolymorphicReference < ActiveRecord::Migration[5.1]
+class AddPolymorphicReference < ActiveRecord::Migration[5.0]
   def change
     add_reference(:comments, :user, polymorphic: true)
   end

--- a/spec/fixtures/migrate/18_add_reference_with_index.rb
+++ b/spec/fixtures/migrate/18_add_reference_with_index.rb
@@ -1,4 +1,4 @@
-class AddReferenceWithIndex < ActiveRecord::Migration
+class AddReferenceWithIndex < ActiveRecord::Migration[5.1]
   def change
     add_reference(:comments, :user, index: true)
   end

--- a/spec/fixtures/migrate/18_add_reference_with_index.rb
+++ b/spec/fixtures/migrate/18_add_reference_with_index.rb
@@ -1,4 +1,4 @@
-class AddReferenceWithIndex < ActiveRecord::Migration[5.1]
+class AddReferenceWithIndex < ActiveRecord::Migration[5.0]
   def change
     add_reference(:comments, :user, index: true)
   end

--- a/spec/fixtures/migrate/19_add_polymorphic_reference_with_index.rb
+++ b/spec/fixtures/migrate/19_add_polymorphic_reference_with_index.rb
@@ -1,4 +1,4 @@
-class AddPolymorphicReferenceWithIndex < ActiveRecord::Migration
+class AddPolymorphicReferenceWithIndex < ActiveRecord::Migration[5.1]
   def change
     add_reference(:comments, :user, polymorphic: true, index: true)
   end

--- a/spec/fixtures/migrate/19_add_polymorphic_reference_with_index.rb
+++ b/spec/fixtures/migrate/19_add_polymorphic_reference_with_index.rb
@@ -1,4 +1,4 @@
-class AddPolymorphicReferenceWithIndex < ActiveRecord::Migration[5.1]
+class AddPolymorphicReferenceWithIndex < ActiveRecord::Migration[5.0]
   def change
     add_reference(:comments, :user, polymorphic: true, index: true)
   end

--- a/spec/fixtures/migrate/1_create_column_on_comments.rb
+++ b/spec/fixtures/migrate/1_create_column_on_comments.rb
@@ -1,10 +1,10 @@
-class CreateColumnOnComments < ActiveRecord::Migration
+class CreateColumnOnComments < ActiveRecord::Migration[5.1]
   def change
     add_column(
       :comments,
       :some_id_field,
       :integer,
-      { limit: 11, default: nil }
+      { limit: 8, default: nil }
     )
   end
 end

--- a/spec/fixtures/migrate/1_create_column_on_comments.rb
+++ b/spec/fixtures/migrate/1_create_column_on_comments.rb
@@ -1,4 +1,4 @@
-class CreateColumnOnComments < ActiveRecord::Migration[5.1]
+class CreateColumnOnComments < ActiveRecord::Migration[5.0]
   def change
     add_column(
       :comments,

--- a/spec/fixtures/migrate/20_remove_reference.rb
+++ b/spec/fixtures/migrate/20_remove_reference.rb
@@ -1,4 +1,4 @@
-class RemoveReference < ActiveRecord::Migration
+class RemoveReference < ActiveRecord::Migration[5.1]
   def change
     remove_reference :comments, :user
   end

--- a/spec/fixtures/migrate/20_remove_reference.rb
+++ b/spec/fixtures/migrate/20_remove_reference.rb
@@ -1,4 +1,4 @@
-class RemoveReference < ActiveRecord::Migration[5.1]
+class RemoveReference < ActiveRecord::Migration[5.0]
   def change
     remove_reference :comments, :user
   end

--- a/spec/fixtures/migrate/21_remove_polymorphic_reference.rb
+++ b/spec/fixtures/migrate/21_remove_polymorphic_reference.rb
@@ -1,4 +1,4 @@
-class RemovePolymorphicReference < ActiveRecord::Migration
+class RemovePolymorphicReference < ActiveRecord::Migration[5.1]
   def change
     remove_reference :comments, :user, polymorphic: true
   end

--- a/spec/fixtures/migrate/21_remove_polymorphic_reference.rb
+++ b/spec/fixtures/migrate/21_remove_polymorphic_reference.rb
@@ -1,4 +1,4 @@
-class RemovePolymorphicReference < ActiveRecord::Migration[5.1]
+class RemovePolymorphicReference < ActiveRecord::Migration[5.0]
   def change
     remove_reference :comments, :user, polymorphic: true
   end

--- a/spec/fixtures/migrate/22_add_timestamp_on_comments.rb
+++ b/spec/fixtures/migrate/22_add_timestamp_on_comments.rb
@@ -1,4 +1,4 @@
-class AddTimestampOnComments < ActiveRecord::Migration
+class AddTimestampOnComments < ActiveRecord::Migration[5.1]
   def change
     add_timestamps :comments
   end

--- a/spec/fixtures/migrate/22_add_timestamp_on_comments.rb
+++ b/spec/fixtures/migrate/22_add_timestamp_on_comments.rb
@@ -1,4 +1,4 @@
-class AddTimestampOnComments < ActiveRecord::Migration[5.1]
+class AddTimestampOnComments < ActiveRecord::Migration[5.0]
   def change
     add_timestamps :comments
   end

--- a/spec/fixtures/migrate/23_remove_timestamp_on_comments.rb
+++ b/spec/fixtures/migrate/23_remove_timestamp_on_comments.rb
@@ -1,4 +1,4 @@
-class RemoveTimestampOnComments < ActiveRecord::Migration
+class RemoveTimestampOnComments < ActiveRecord::Migration[5.1]
   def change
     remove_timestamps :comments
   end

--- a/spec/fixtures/migrate/23_remove_timestamp_on_comments.rb
+++ b/spec/fixtures/migrate/23_remove_timestamp_on_comments.rb
@@ -1,4 +1,4 @@
-class RemoveTimestampOnComments < ActiveRecord::Migration[5.1]
+class RemoveTimestampOnComments < ActiveRecord::Migration[5.0]
   def change
     remove_timestamps :comments
   end

--- a/spec/fixtures/migrate/24_rename_comments_to_new_comments.rb
+++ b/spec/fixtures/migrate/24_rename_comments_to_new_comments.rb
@@ -1,4 +1,4 @@
-class RenameCommentsToNewComments < ActiveRecord::Migration
+class RenameCommentsToNewComments < ActiveRecord::Migration[5.1]
   def change
     rename_table :comments, :new_comments
   end

--- a/spec/fixtures/migrate/24_rename_comments_to_new_comments.rb
+++ b/spec/fixtures/migrate/24_rename_comments_to_new_comments.rb
@@ -1,4 +1,4 @@
-class RenameCommentsToNewComments < ActiveRecord::Migration[5.1]
+class RenameCommentsToNewComments < ActiveRecord::Migration[5.0]
   def change
     rename_table :comments, :new_comments
   end

--- a/spec/fixtures/migrate/25_rename_some_id_field_to_new_id_field.rb
+++ b/spec/fixtures/migrate/25_rename_some_id_field_to_new_id_field.rb
@@ -1,4 +1,4 @@
-class RenameSomeIdFieldToNewIdField < ActiveRecord::Migration
+class RenameSomeIdFieldToNewIdField < ActiveRecord::Migration[5.1]
   def change
     rename_column :comments, :some_id_field, :new_id_field
   end

--- a/spec/fixtures/migrate/25_rename_some_id_field_to_new_id_field.rb
+++ b/spec/fixtures/migrate/25_rename_some_id_field_to_new_id_field.rb
@@ -1,4 +1,4 @@
-class RenameSomeIdFieldToNewIdField < ActiveRecord::Migration[5.1]
+class RenameSomeIdFieldToNewIdField < ActiveRecord::Migration[5.0]
   def change
     rename_column :comments, :some_id_field, :new_id_field
   end

--- a/spec/fixtures/migrate/2_create_index_on_comments.rb
+++ b/spec/fixtures/migrate/2_create_index_on_comments.rb
@@ -1,4 +1,4 @@
-class CreateIndexOnComments < ActiveRecord::Migration
+class CreateIndexOnComments < ActiveRecord::Migration[5.1]
   def change
     add_index :comments, :some_id_field
   end

--- a/spec/fixtures/migrate/2_create_index_on_comments.rb
+++ b/spec/fixtures/migrate/2_create_index_on_comments.rb
@@ -1,4 +1,4 @@
-class CreateIndexOnComments < ActiveRecord::Migration[5.1]
+class CreateIndexOnComments < ActiveRecord::Migration[5.0]
   def change
     add_index :comments, :some_id_field
   end

--- a/spec/fixtures/migrate/3_create_unique_index_on_comments.rb
+++ b/spec/fixtures/migrate/3_create_unique_index_on_comments.rb
@@ -1,4 +1,4 @@
-class CreateUniqueIndexOnComments < ActiveRecord::Migration
+class CreateUniqueIndexOnComments < ActiveRecord::Migration[5.1]
   def change
     add_index :comments, :some_id_field, unique: true
   end

--- a/spec/fixtures/migrate/3_create_unique_index_on_comments.rb
+++ b/spec/fixtures/migrate/3_create_unique_index_on_comments.rb
@@ -1,4 +1,4 @@
-class CreateUniqueIndexOnComments < ActiveRecord::Migration[5.1]
+class CreateUniqueIndexOnComments < ActiveRecord::Migration[5.0]
   def change
     add_index :comments, :some_id_field, unique: true
   end

--- a/spec/fixtures/migrate/4_ddl_statement_on_comments.rb
+++ b/spec/fixtures/migrate/4_ddl_statement_on_comments.rb
@@ -1,4 +1,4 @@
-class DdlStatementOnComments < ActiveRecord::Migration
+class DdlStatementOnComments < ActiveRecord::Migration[5.1]
   def up
     Lhm.change_table :comments, { stride: 5000, throttle: 150 } do |c|
       c.ddl("alter table #{c.name} my up ddl statement")

--- a/spec/fixtures/migrate/4_ddl_statement_on_comments.rb
+++ b/spec/fixtures/migrate/4_ddl_statement_on_comments.rb
@@ -1,4 +1,4 @@
-class DdlStatementOnComments < ActiveRecord::Migration[5.1]
+class DdlStatementOnComments < ActiveRecord::Migration[5.0]
   def up
     Lhm.change_table :comments, { stride: 5000, throttle: 150 } do |c|
       c.ddl("alter table #{c.name} my up ddl statement")

--- a/spec/fixtures/migrate/5_no_statements.rb
+++ b/spec/fixtures/migrate/5_no_statements.rb
@@ -1,4 +1,4 @@
-class NoStatements < ActiveRecord::Migration
+class NoStatements < ActiveRecord::Migration[5.1]
   def up
     Lhm.change_table :comments, { stride: 5000, throttle: 150 } do |c|
     end

--- a/spec/fixtures/migrate/5_no_statements.rb
+++ b/spec/fixtures/migrate/5_no_statements.rb
@@ -1,4 +1,4 @@
-class NoStatements < ActiveRecord::Migration[5.1]
+class NoStatements < ActiveRecord::Migration[5.0]
   def up
     Lhm.change_table :comments, { stride: 5000, throttle: 150 } do |c|
     end

--- a/spec/fixtures/migrate/6_broken_ddl_statement_on_comments.rb
+++ b/spec/fixtures/migrate/6_broken_ddl_statement_on_comments.rb
@@ -1,4 +1,4 @@
-class BrokenDdlStatementOnComments < ActiveRecord::Migration
+class BrokenDdlStatementOnComments < ActiveRecord::Migration[5.1]
   def up
     Lhm.change_table :comments, { stride: 5000, throttle: 150 } do |c|
       c.ddl('bla bla bla')

--- a/spec/fixtures/migrate/6_broken_ddl_statement_on_comments.rb
+++ b/spec/fixtures/migrate/6_broken_ddl_statement_on_comments.rb
@@ -1,4 +1,4 @@
-class BrokenDdlStatementOnComments < ActiveRecord::Migration[5.1]
+class BrokenDdlStatementOnComments < ActiveRecord::Migration[5.0]
   def up
     Lhm.change_table :comments, { stride: 5000, throttle: 150 } do |c|
       c.ddl('bla bla bla')

--- a/spec/fixtures/migrate/7_non_lhm_migration.rb
+++ b/spec/fixtures/migrate/7_non_lhm_migration.rb
@@ -1,4 +1,4 @@
-class NonLhmMigration < ActiveRecord::Migration
+class NonLhmMigration < ActiveRecord::Migration[5.1]
   def up
     Lhm.change_table :products, { stride: 5000, throttle: 150 } do |p|
       p.add_column :price, 'VARCHAR(255)'

--- a/spec/fixtures/migrate/7_non_lhm_migration.rb
+++ b/spec/fixtures/migrate/7_non_lhm_migration.rb
@@ -1,4 +1,4 @@
-class NonLhmMigration < ActiveRecord::Migration[5.1]
+class NonLhmMigration < ActiveRecord::Migration[5.0]
   def up
     Lhm.change_table :products, { stride: 5000, throttle: 150 } do |p|
       p.add_column :price, 'VARCHAR(255)'

--- a/spec/fixtures/migrate/8_create_things.rb
+++ b/spec/fixtures/migrate/8_create_things.rb
@@ -1,4 +1,4 @@
-class CreateThings < ActiveRecord::Migration
+class CreateThings < ActiveRecord::Migration[5.1]
   def up
     create_table :things do |t|
       t.datetime :created_at, null: false

--- a/spec/fixtures/migrate/8_create_things.rb
+++ b/spec/fixtures/migrate/8_create_things.rb
@@ -1,4 +1,4 @@
-class CreateThings < ActiveRecord::Migration[5.1]
+class CreateThings < ActiveRecord::Migration[5.0]
   def up
     create_table :things do |t|
       t.datetime :created_at, null: false

--- a/spec/fixtures/migrate/9_data_migration_with_update_all.rb
+++ b/spec/fixtures/migrate/9_data_migration_with_update_all.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithUpdateAll < ActiveRecord::Migration
+class DataMigrationWithUpdateAll < ActiveRecord::Migration[5.1]
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/fixtures/migrate/9_data_migration_with_update_all.rb
+++ b/spec/fixtures/migrate/9_data_migration_with_update_all.rb
@@ -1,4 +1,4 @@
-class DataMigrationWithUpdateAll < ActiveRecord::Migration[5.1]
+class DataMigrationWithUpdateAll < ActiveRecord::Migration[5.0]
   class Comment < ActiveRecord::Base; end
 
   def up

--- a/spec/integration/columns_spec.rb
+++ b/spec/integration/columns_spec.rb
@@ -73,7 +73,7 @@ describe Departure, integration: true do
           :comments,
           :some_id_field,
           :integer,
-          { limit: 11, default: nil }
+          { limit: 8, default: nil }
         )
       end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -16,21 +16,6 @@ describe Departure, integration: true do
   end
 
   describe 'logging' do
-    context 'when the migration logging is enabled' do
-      around(:each) do |example|
-        original_verbose = ActiveRecord::Migration.verbose
-        ActiveRecord::Migration.verbose = true
-        example.run
-        ActiveRecord::Migration.verbose = original_verbose
-      end
-
-      it 'sends the output to the stdout' do
-        expect do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
-        end.to output.to_stdout
-      end
-    end
-
     context 'when the migration logging is disabled' do
       around(:each) do |example|
         original_verbose = ActiveRecord::Migration.verbose
@@ -43,6 +28,21 @@ describe Departure, integration: true do
         expect do
           ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
         end.to_not output.to_stdout
+      end
+    end
+
+    context 'when the migration logging is enabled' do
+      around(:each) do |example|
+        original_verbose = ActiveRecord::Migration.verbose
+        ActiveRecord::Migration.verbose = true
+        example.run
+        ActiveRecord::Migration.verbose = original_verbose
+      end
+
+      it 'sends the output to the stdout' do
+        expect do
+          ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+        end.to output.to_stdout
       end
     end
   end
@@ -206,11 +206,11 @@ describe Departure, integration: true do
       it 'does not allow to migrate' do
         expect do
           ClimateControl.modify PERCONA_ARGS: '--arg=foo' do
-            Departure.load
             ActiveRecord::Migrator.migrate(migrations_paths, 1)
           end
+        end.to raise_error do |exception|
+          ( exception.cause == Departure::ArgumentsNotSupported ) && ( excepton.to_s =~ /Unknown option: arg/ )
         end
-          .to raise_error(Departure::ArgumentsNotSupported)
       end
     end
   end

--- a/spec/lhm/column_with_sql_spec.rb
+++ b/spec/lhm/column_with_sql_spec.rb
@@ -86,6 +86,14 @@ describe Lhm::ColumnWithSql do
       context 'with limit' do
         subject { column.attributes[1] }
 
+        # ActiveRecord 5.1.x special cases tinyint(1) to be Type::Boolean with
+        # no limit specified in abstract AbstractMysqlAdapter. Perhaps this is
+        # a bug and it should do:
+        #
+        # m.register_type %r(^tinyint\(1\))i, Type::Boolean.new(limit: 1) if emulate_booleans
+        #
+        # But until that changes, this test will return nil for a limit instead
+        # of 1, as it did previously.
         let(:definition) { 'TINYINT(1)' }
         its([:limit]) { is_expected.to eq(1) }
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'bundler'
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
Hey @sauloperez @wyhaines, 

This PR takes @wyhaines's work (https://github.com/redbooth/departure/pull/81) and adds a couple of changes to make the gem Rails 5.0 compatible.

It's still WIP because `spec/lhm/column_with_sql_spec.rb` is failing with a lot of these:

```
  48) Lhm::ColumnWithSql#attributes when defining DATETIME [0]
      Failure/Error:
        @column ||= self.class.column_factory.new(
          name,
          default_value,
          cast_type,
          null_value
        )

      NoMethodError:
        undefined method `sql_type' for #<ActiveRecord::Type::DateTime:0x007f910fde7c98>
      # /Users/etagwerker/.rvm/gems/ruby-2.3.3@dep50/gems/activerecord-5.0.6/lib/active_record/connection_adapters/column.rb:8:in `sql_type'
      # /Users/etagwerker/.rvm/gems/ruby-2.3.3@dep50/gems/activerecord-5.0.6/lib/active_record/connection_adapters/mysql/column.rb:19:in `blob_or_text_column?'
      # /Users/etagwerker/.rvm/gems/ruby-2.3.3@dep50/gems/activerecord-5.0.6/lib/active_record/connection_adapters/mysql/column.rb:43:in `assert_valid_default'
      # /Users/etagwerker/.rvm/gems/ruby-2.3.3@dep50/gems/activerecord-5.0.6/lib/active_record/connection_adapters/mysql/column.rb:9:in `initialize'
      # ./lib/lhm/column_with_sql.rb:56:in `new'
      # ./lib/lhm/column_with_sql.rb:56:in `column'
      # ./lib/lhm/column_with_sql.rb:30:in `attributes'
      # ./spec/lhm/column_with_sql_spec.rb:8:in `block (3 levels) in <top (required)>'
      # ./spec/lhm/column_with_sql_spec.rb:191:in `block (4 levels) in <top (required)>'
```

I solved a couple of conflicts in the process.

I'll let you know once the build is passing.

Please let me know if you have any comments.

Thank you! 