### PR TITLE
Permit user to determine safety of PERCONA_ARGS on migrate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ### Added
 ### Changed
+
+- Permit PERCONA_ARGS to be applied to db:migrate tasks
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ or even mulitple arguments
 $ PERCONA_ARGS='--chunk-time=1 --critical-load=55' bundle exec rake db:migrate:up VERSION=xxx
 ```
 
-Use caution when using PERCONA_ARGS with db:migrate, as your args will be applied
+Use caution when using PERCONA_ARGS with `db:migrate`, as your args will be applied
 to every call that Departure makes to pt-osc.
 
 #### with global configuration

--- a/README.md
+++ b/README.md
@@ -102,9 +102,8 @@ or even mulitple arguments
 $ PERCONA_ARGS='--chunk-time=1 --critical-load=55' bundle exec rake db:migrate:up VERSION=xxx
 ```
 
-This however, only works for `db:migrate:up` or `db:migrate:down` rake tasks and
-not with `db:migrate`. The settings you provide can't be generalized as these
-vary depending on the database table and the kind of changes you apply.
+Use caution when using PERCONA_ARGS with db:migrate, as your args will be applied
+to every call that Departure makes to pt-osc.
 
 #### with global configuration
 

--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -40,7 +40,6 @@ module Departure
       #
       # @raise [ArgumentsNotSupported] if PERCONA_ARGS has any value
       def migrate(migrations_paths, target_version = nil, &block)
-        raise ArgumentsNotSupported if ENV['PERCONA_ARGS'].present?
         original_migrate(migrations_paths, target_version, &block)
       end
     end

--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -30,16 +30,6 @@ module Departure
   # Hooks Percona Migrator into Rails migrations by replacing the configured
   # database adapter
   def self.load
-    ActiveRecord::Migrator.instance_eval do
-      class << self
-        alias original_migrate migrate
-      end
-
-      def migrate(migrations_paths, target_version = nil, &block)
-        original_migrate(migrations_paths, target_version, &block)
-      end
-    end
-
     ActiveRecord::Migration.class_eval do
       alias_method :original_migrate, :migrate
 

--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -35,10 +35,6 @@ module Departure
         alias original_migrate migrate
       end
 
-      # Checks whether arguments are being passed through PERCONA_ARGS when running
-      # the db:migrate rake task
-      #
-      # @raise [ArgumentsNotSupported] if PERCONA_ARGS has any value
       def migrate(migrations_paths, target_version = nil, &block)
         original_migrate(migrations_paths, target_version, &block)
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -205,10 +205,10 @@ describe Departure, integration: true do
 
       it 'does not allow to migrate' do
         expect do
-          ClimateControl.modify PERCONA_ARGS: '--arg=foo' do
+          ClimateControl.modify PERCONA_ARGS: '--sleep=1' do
             ActiveRecord::Migrator.migrate(migrations_paths, 1)
           end
-        end.to raise_error do |exception|
+        end.not_to raise_error do |exception|
           ( exception.cause == Departure::ArgumentsNotSupported ) && ( excepton.to_s =~ /Unknown option: arg/ )
         end
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -200,18 +200,5 @@ describe Departure, integration: true do
       end
     end
 
-    context 'and the db:migrate rake task is executed' do
-      let(:migrations_paths) { [MIGRATION_FIXTURES] }
-
-      it 'does not allow to migrate' do
-        expect do
-          ClimateControl.modify PERCONA_ARGS: '--sleep=1' do
-            ActiveRecord::Migrator.migrate(migrations_paths, 1)
-          end
-        end.not_to raise_error do |exception|
-          ( exception.cause == Departure::ArgumentsNotSupported ) && ( excepton.to_s =~ /Unknown option: arg/ )
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Much of the use case for PERCONA_ARGS, at least as we use Departure and pt-osc, is to provide some performance tuning parameters to pt-osc. Departure should allow us to determine the safety of this ourselves.