### PR TITLE
Increase the maximum size of a single read to a more reasonable value.

### DIFF
--- a/departure_error.log
+++ b/departure_error.log
@@ -1,1 +1,1 @@
-sh: whatevarrr666: command not found
+No foreign keys reference `departure_test`.`comments`; ignoring --alter-foreign-keys-method.

--- a/lib/departure/command.rb
+++ b/lib/departure/command.rb
@@ -44,7 +44,7 @@ module Departure
         begin
           loop do
             IO.select([stdout])
-            data = stdout.read_nonblock(8)
+            data = stdout.read_nonblock(8192)
             logger.write_no_newline(data)
           end
         rescue EOFError # rubocop:disable Lint/HandleExceptions

--- a/spec/departure/command_spec.rb
+++ b/spec/departure/command_spec.rb
@@ -59,9 +59,7 @@ describe Departure::Command do
     it 'logs the command\'s output' do
       runner.run
 
-      expect(logger).to have_received(:write_no_newline).with('hello wo')
-      expect(logger).to have_received(:write_no_newline).with('rld\\ntod')
-      expect(logger).to have_received(:write_no_newline).with('o roto')
+      expect(logger).to have_received(:write_no_newline).with('hello world\\ntodo roto')
     end
 
     context 'on failure' do


### PR DESCRIPTION
There is no point 8 character blocks when combined with read_nonblock.
An 8k block will let Departure read whatever io pt-osc has available
all in one read operation.