### PR TITLE
Remove ignored departure_error.log file

### DIFF
--- a/departure_error.log
+++ b/departure_error.log
@@ -1,1 +1,0 @@
-No foreign keys reference `departure_test`.`comments`; ignoring --alter-foreign-keys-method.


### PR DESCRIPTION
This file was being tracked by Git before we added it to .gitignore, so I'm removing it.