### PR TITLE
Add proper support for Foreign Keys Removing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ### Added
 ### Changed
+### Deprecated
+### Removed
+### Fixed
+
+- Fix support for removing foreign keys
+
+## [6.1.0] - 2018-02-27
+
+### Added
+### Changed
 
 - Permit PERCONA_ARGS to be applied to db:migrate tasks
 

--- a/departure.gemspec
+++ b/departure.gemspec
@@ -8,8 +8,8 @@ require 'departure/version'
 Gem::Specification.new do |spec|
   spec.name          = 'departure'
   spec.version       = Departure::VERSION
-  spec.authors       = ['Ilya Zayats', 'Pau Pérez', 'Fran Casas', 'Jorge Morante', 'Enrico Stano', 'Adrian Serafin', 'Kirk Haines']
-  spec.email         = ['ilya.zayats@redbooth.com', 'pau.perez@redbooth.com', 'fran.casas@redbooth.com', 'jorge.morante@redbooth.com', 'adrian@softmad.pl', 'wyhaines@gmail.com']
+  spec.authors       = ['Ilya Zayats', 'Pau Pérez', 'Fran Casas', 'Jorge Morante', 'Enrico Stano', 'Adrian Serafin', 'Kirk Haines', 'Guillermo Iguaran']
+  spec.email         = ['ilya.zayats@redbooth.com', 'pau.perez@redbooth.com', 'fran.casas@redbooth.com', 'jorge.morante@redbooth.com', 'adrian@softmad.pl', 'wyhaines@gmail.com', 'guilleiguaran@gmail.com']
 
   spec.summary       = %q(pt-online-schema-change runner for ActiveRecord migrations)
   spec.description   = %q(Execute your ActiveRecord migrations with Percona's pt-online-schema-change. Formerly known as Percona Migrator.)

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -46,6 +46,12 @@ module ActiveRecord
         end
       end
 
+      class SchemaCreation < ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation
+        def visit_DropForeignKey(name) # rubocop:disable Naming/MethodName
+          "DROP FOREIGN KEY _#{name}"
+        end
+      end
+
       extend Forwardable
 
       ADAPTER_NAME = 'Percona'.freeze
@@ -114,6 +120,10 @@ module ActiveRecord
       def remove_index(table_name, options = {})
         index_name = index_name_for_remove(table_name, options)
         execute "ALTER TABLE #{quote_table_name(table_name)} DROP INDEX #{quote_column_name(index_name)}"
+      end
+
+      def schema_creation
+        SchemaCreation.new(self)
       end
 
       # Returns the MySQL error number from the exception. The

--- a/spec/fixtures/migrate/26_add_foreign_key.rb
+++ b/spec/fixtures/migrate/26_add_foreign_key.rb
@@ -1,0 +1,5 @@
+class AddForeignKey < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key(:comments, :products)
+  end
+end

--- a/spec/fixtures/migrate/27_remove_foreign_key.rb
+++ b/spec/fixtures/migrate/27_remove_foreign_key.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKey < ActiveRecord::Migration[5.1]
+  def change
+    remove_foreign_key(:comments, :products)
+  end
+end

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -4,9 +4,9 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::Migrator.migrations(MIGRATION_FIXTURES)
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations
   end
-  let(:migration_path) { [MIGRATION_FIXTURES] }
+  let(:migration_paths) { [MIGRATION_FIXTURES] }
 
   let(:direction) { :up }
 
@@ -24,7 +24,7 @@ describe Departure, integration: true do
     end
 
     it 'adds a foreign key' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(:comments).to have_foreign_key_on('product_id')
     end
   end
@@ -47,8 +47,8 @@ describe Departure, integration: true do
       )
     end
 
-   it 'removes a foreign key' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+    it 'removes a foreign key' do
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
     end
   end

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Departure, integration: true do
+  class Comment < ActiveRecord::Base; end
+
+  let(:migration_fixtures) do
+    ActiveRecord::Migrator.migrations(MIGRATION_FIXTURES)
+  end
+  let(:migration_path) { [MIGRATION_FIXTURES] }
+
+  let(:direction) { :up }
+
+  context 'adding foreign keys' do
+    let(:version) { 26 }
+
+    before do
+      ActiveRecord::Base.connection.create_table(:products)
+
+      ActiveRecord::Base.connection.add_column(
+        :comments,
+        :product_id,
+        :bigint
+      )
+    end
+
+    it 'adds a foreign key' do
+      ActiveRecord::Migrator.run(direction, migration_path, version)
+      expect(:comments).to have_foreign_key_on('product_id')
+    end
+  end
+
+  context 'removing foreign keys' do
+    let(:version) { 27 }
+
+     before do
+       ActiveRecord::Base.connection.create_table(:products)
+
+       ActiveRecord::Base.connection.add_column(
+          :comments,
+          :product_id,
+          :bigint
+       )
+
+      ActiveRecord::Base.connection.add_foreign_key(
+        :comments,
+        :products
+      )
+    end
+
+   it 'removes a foreign key' do
+      ActiveRecord::Migrator.run(direction, migration_path, version)
+      expect(:comments).not_to have_foreign_key_on('product_id')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require 'lhm'
 
 require 'support/matchers/have_column'
 require 'support/matchers/have_index'
+require 'support/matchers/have_foreign_key_on'
 require 'support/table_methods'
 
 db_config = Configuration.new

--- a/spec/support/matchers/have_foreign_key_on.rb
+++ b/spec/support/matchers/have_foreign_key_on.rb
@@ -1,0 +1,18 @@
+# Defines a matcher to check whether a table contains a foreign key on a given column.
+#
+# @example Check the comments table contains a foreign key on user_id column:
+#
+#   expect(:comments).to have_foreign_key('user_id')
+RSpec::Matchers.define :have_foreign_key_on do |expected|
+  match do |actual|
+    expect(foreign_key_column_names(actual)).to include(expected)
+  end
+
+  def foreign_key_column_names(table_name)
+    foreign_keys(table_name).map{|fk| fk.options[:column]}
+  end
+
+  def foreign_keys(table_name)
+    ActiveRecord::Base.connection.foreign_keys(table_name)
+  end
+end

--- a/test_database.rb
+++ b/test_database.rb
@@ -59,7 +59,7 @@ class TestDatabase
     sql = [
       "USE #{@database}",
       "DROP TABLE IF EXISTS comments",
-      "CREATE TABLE comments ( id int(12) NOT NULL AUTO_INCREMENT, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"
+      "CREATE TABLE comments ( id bigint(20) NOT NULL AUTO_INCREMENT, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"
     ]
 
     run_commands(sql)

--- a/test_database.rb
+++ b/test_database.rb
@@ -35,8 +35,8 @@ class TestDatabase
   def drop_and_create_schema_migrations_table
    sql = [
     "USE #{@database}",
-    "DROP TABLE IF EXISTS schema_migrations",
-    "CREATE TABLE schema_migrations ( version varchar(255) COLLATE utf8_unicode_ci NOT NULL, UNIQUE KEY unique_schema_migrations (version)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"
+    'DROP TABLE IF EXISTS schema_migrations',
+    'CREATE TABLE schema_migrations ( version varchar(255) COLLATE utf8_unicode_ci NOT NULL, UNIQUE KEY unique_schema_migrations (version)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci'
     ]
 
     run_commands(sql)
@@ -58,19 +58,19 @@ class TestDatabase
   def drop_and_create_comments_table
     sql = [
       "USE #{@database}",
-      "DROP TABLE IF EXISTS comments",
-      "CREATE TABLE comments ( id bigint(20) NOT NULL AUTO_INCREMENT, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"
+      'DROP TABLE IF EXISTS comments',
+      'CREATE TABLE comments ( id bigint(20) NOT NULL AUTO_INCREMENT, PRIMARY KEY (id)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci'
     ]
 
     run_commands(sql)
   end
 
   def run_commands(sql)
-    conn.execute("START TRANSACTION")
+    conn.execute('START TRANSACTION')
     sql.each { |str|
       conn.execute(str)
     }
-    conn.execute("COMMIT")
+    conn.execute('COMMIT')
   end
 
   def conn


### PR DESCRIPTION
For `DROP FOREIGN KEY constraint_name` with pt-online-schema-change
requires specifying `_constraint_name` rather than the real
constraint_name. This is due to a limitation in MySQL:
pt-online-schema-change adds a leading underscore to foreign key
constraint names when creating the new table.

Additionally, this add specs to ensure that the addition and deletion
of foreign keys works correctly.

More details about this:
https://www.percona.com/blog/2017/03/21/dropping-foreign-key-constraint-using-pt-online-schema-change-2/

This closes https://github.com/departurerb/departure/issues/18