### PR TITLE
Depend only in railties and activerecord instead of full rails

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rails', '~> 5.1.0'
+  spec.add_runtime_dependency 'railties', '~> 5.1.0'
+  spec.add_runtime_dependency 'activerecord', '~> 5.1.0'
   spec.add_runtime_dependency 'mysql2', '~> 0.4.0'
 
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This removes actioncable, actionmailer, activejob and their dependencies.

Before:
```
~/src/departure[master] % wc -l Gemfile.lock
     171 Gemfile.lock
```

After:
```
~/src/departure[master] % wc -l Gemfile.lock
     131 Gemfile.lock
```

Extra: CI should be faster because it needs to download/install fewer dependencies.