### PR TITLE
Active Record 5.2 support

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'railties', '~> 5.1.0'
-  spec.add_runtime_dependency 'activerecord', '~> 5.1.0'
+  spec.add_runtime_dependency 'railties', '~> 5.2.0'
+  spec.add_runtime_dependency 'activerecord', '~> 5.2.0'
   spec.add_runtime_dependency 'mysql2', '~> 0.4.0'
 
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/lhm/column_with_sql.rb
+++ b/lib/lhm/column_with_sql.rb
@@ -52,7 +52,7 @@ module Lhm
     #
     # @return [column_factory]
     def column
-      cast_type = ActiveRecord::Base.connection.lookup_cast_type(definition)
+      cast_type = ActiveRecord::Base.connection.send(:lookup_cast_type, definition)
       metadata = ActiveRecord::ConnectionAdapters::SqlTypeMetadata.new(
         type: cast_type.type,
         sql_type: definition,

--- a/spec/integration/columns_spec.rb
+++ b/spec/integration/columns_spec.rb
@@ -4,9 +4,9 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::Migrator.migrations(MIGRATION_FIXTURES)
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations
   end
-  let(:migration_path) { [MIGRATION_FIXTURES] }
+  let(:migration_paths) { [MIGRATION_FIXTURES] }
 
   let(:direction) { :up }
 
@@ -78,12 +78,12 @@ describe Departure, integration: true do
       end
 
       it 'changes the column name' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).to have_column('new_id_field')
       end
 
       it 'does not keep the old column' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).not_to have_column('some_id_field')
       end
     end
@@ -103,12 +103,12 @@ describe Departure, integration: true do
       let(:version) { 14 }
 
       it 'sets the column to allow nulls' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(column.null).to be_truthy
       end
 
       it 'marks the migration as up' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
     end
@@ -117,12 +117,12 @@ describe Departure, integration: true do
       let(:version) { 15 }
 
       it 'sets the column not to allow nulls' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(column.null).to be_falsey
       end
 
       it 'marks the migration as up' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
     end
@@ -132,12 +132,12 @@ describe Departure, integration: true do
     let(:version) { 22 }
 
     it 'adds a created_at column' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(:comments).to have_column('created_at')
     end
 
     it 'adds a updated_at column' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(:comments).to have_column('updated_at')
     end
   end
@@ -154,12 +154,12 @@ describe Departure, integration: true do
     end
 
     it 'removes the created_at column' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(:comments).not_to have_column('created_at')
     end
 
     it 'removes the updated_at column' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(:comments).not_to have_column('updated_at')
     end
   end

--- a/spec/integration/data_migrations_spec.rb
+++ b/spec/integration/data_migrations_spec.rb
@@ -25,9 +25,8 @@ describe Departure, integration: true do
     let(:version) { 9 }
 
     it 'updates all the required data' do
-      ActiveRecord::Migrator.run(
+      ActiveRecord::MigrationContext.new(migration_fixtures).run(
         direction,
-        migration_fixtures,
         version
       )
 
@@ -35,9 +34,8 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::Migrator.run(
+      ActiveRecord::MigrationContext.new(migration_fixtures).run(
         direction,
-        migration_fixtures,
         version
       )
 
@@ -49,9 +47,8 @@ describe Departure, integration: true do
     let(:version) { 10 }
 
     it 'updates all the required data' do
-      ActiveRecord::Migrator.run(
+      ActiveRecord::MigrationContext.new(migration_fixtures).run(
         direction,
-        migration_fixtures,
         version
       )
 
@@ -59,9 +56,8 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::Migrator.run(
+      ActiveRecord::MigrationContext.new(migration_fixtures).run(
         direction,
-        migration_fixtures,
         version
       )
 
@@ -73,9 +69,8 @@ describe Departure, integration: true do
     let(:version) { 11 }
 
     it 'updates all the required data' do
-      ActiveRecord::Migrator.run(
+      ActiveRecord::MigrationContext.new(migration_fixtures).run(
         direction,
-        migration_fixtures,
         version
       )
 
@@ -83,9 +78,8 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::Migrator.run(
+      ActiveRecord::MigrationContext.new(migration_fixtures).run(
         direction,
-        migration_fixtures,
         version
       )
 
@@ -97,9 +91,8 @@ describe Departure, integration: true do
     let(:version) { 12 }
 
     it 'updates all the required data' do
-      ActiveRecord::Migrator.run(
+      ActiveRecord::MigrationContext.new(migration_fixtures).run(
         direction,
-        migration_fixtures,
         version
       )
 
@@ -107,9 +100,8 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::Migrator.run(
+      ActiveRecord::MigrationContext.new(migration_fixtures).run(
         direction,
-        migration_fixtures,
         version
       )
 

--- a/spec/integration/indexes_spec.rb
+++ b/spec/integration/indexes_spec.rb
@@ -4,9 +4,10 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::Migrator.migrations(MIGRATION_FIXTURES)
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations
   end
-  let(:migration_path) { [MIGRATION_FIXTURES] }
+
+  let(:migration_paths) { [MIGRATION_FIXTURES] }
 
   let(:direction) { :up }
 
@@ -93,12 +94,12 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).to have_index('new_index_comments_on_some_id_field')
       end
 
       it 'marks the migration as down' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
     end
@@ -115,14 +116,14 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
 
         expect(unique_indexes_from(:comments))
           .to match_array(['index_comments_on_some_id_field'])
       end
 
       it 'marks the migration as up' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
     end
@@ -131,19 +132,19 @@ describe Departure, integration: true do
       let(:direction) { :down }
 
       before do
-        ActiveRecord::Migrator.run(:up, migration_path, 1)
-        ActiveRecord::Migrator.run(:up, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(:up, 1)
+        ActiveRecord::MigrationContext.new(migration_paths).run(:up, version)
       end
 
       it 'executes the percona command' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
 
         expect(unique_indexes_from(:comments))
           .not_to match_array(['index_comments_on_some_id_field'])
       end
 
       it 'marks the migration as down' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(1)
       end
     end

--- a/spec/integration/references_spec.rb
+++ b/spec/integration/references_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_path) { [MIGRATION_FIXTURES] }
+  let(:migration_paths) { [MIGRATION_FIXTURES] }
   let(:direction) { :up }
 
   context 'creating references' do
@@ -11,7 +11,7 @@ describe Departure, integration: true do
       let(:version) { 16 }
 
       it 'adds a reference column' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).to have_column('user_id')
       end
     end
@@ -20,12 +20,12 @@ describe Departure, integration: true do
       let(:version) { 17 }
 
       it 'adds a column for the id' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).to have_column('user_id')
       end
 
       it 'adds a column for the type' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).to have_column('user_type')
       end
 
@@ -33,7 +33,7 @@ describe Departure, integration: true do
         let(:version) { 19 }
 
         it 'adds a compound index for both the id and type columns' do
-          ActiveRecord::Migrator.run(direction, migration_path, version)
+          ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
           expect(:comments)
             .to have_index('index_comments_on_user_type_and_user_id')
         end
@@ -44,7 +44,7 @@ describe Departure, integration: true do
       let(:version) { 18 }
 
       it 'adds an index for the reference column' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
 
         expect(:comments).to have_index('index_comments_on_user_id')
       end
@@ -54,23 +54,23 @@ describe Departure, integration: true do
   context 'removing references' do
     let(:version) { 20 }
 
-    before { ActiveRecord::Migrator.run(direction, migration_path, 16) }
+    before { ActiveRecord::MigrationContext.new(migration_paths).run(direction, 16) }
 
     context 'when no option is set' do
       it 'removes the reference column' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).not_to have_column('user_id')
       end
     end
 
     context 'when polymorphic is set to true' do
       it 'removes the reference id column' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).not_to have_column('user_id')
       end
 
       it 'removes the reference type column' do
-        ActiveRecord::Migrator.run(direction, migration_path, version)
+        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
         expect(:comments).not_to have_column('user_type')
       end
     end

--- a/spec/integration/tables_spec.rb
+++ b/spec/integration/tables_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_path) { [MIGRATION_FIXTURES] }
+  let(:migration_paths) { [MIGRATION_FIXTURES] }
   let(:direction) { :up }
 
   context 'creating a table' do
     let(:version) { 8 }
 
     it 'creates the table' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(tables).to include('things')
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(ActiveRecord::Migrator.current_version).to eq(version)
     end
   end
@@ -25,12 +25,12 @@ describe Departure, integration: true do
     let(:direction) { :down }
 
     it 'drops the table' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(tables).not_to include('things')
     end
 
     it 'updates the schema_migrations' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(ActiveRecord::Migrator.current_version).to eq(0)
     end
   end
@@ -39,22 +39,22 @@ describe Departure, integration: true do
     let(:version) { 24 }
 
     before do
-      ActiveRecord::Migrator.run(direction, migration_path, 1)
-      ActiveRecord::Migrator.run(direction, migration_path, 2)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, 1)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, 2)
     end
 
     it 'changes the table name' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(tables).to include('new_comments')
     end
 
     it 'does not keep the old name' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(tables).not_to include('comments')
     end
 
     it 'changes the index names in the new table' do
-      ActiveRecord::Migrator.run(direction, migration_path, version)
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(:new_comments).to have_index('index_new_comments_on_some_id_field')
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -5,9 +5,8 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::Migrator.migrations(MIGRATION_FIXTURES)
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations
   end
-  let(:migration_path) { [MIGRATION_FIXTURES] }
 
   let(:direction) { :up }
 


### PR DESCRIPTION
This adds support for Active Record 5.2.

There one small change in the main code, `ActiveRecord::Base.connection.lookup_cast_type` is now a private method and it is being used in the LHM compatibility layer.

All the other changes are in the specs, all the singleton methods from `ActiveRecord::Migrator` has been moved to instance methods inside of `ActiveRecord::MigrationContext` so we need to update all the specs using `Migrator`.

Props to @aqeelvn that did most of the work on this.