### PR TITLE
Prevent overriding default rails connection_specification_name ("primary")

### DIFF
--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -11,6 +11,7 @@ require 'departure/logger_factory'
 require 'departure/configuration'
 require 'departure/errors'
 require 'departure/command'
+require 'departure/connection_base'
 
 require 'departure/railtie' if defined?(Rails)
 
@@ -59,7 +60,7 @@ module Departure
       def reconnect_with_percona
         connection_config = ActiveRecord::Base
           .connection_config.merge(adapter: 'percona')
-        ActiveRecord::Base.establish_connection(connection_config)
+        Departure::ConnectionBase.establish_connection(connection_config)
       end
     end
   end

--- a/lib/departure/connection_base.rb
+++ b/lib/departure/connection_base.rb
@@ -1,0 +1,8 @@
+module Departure
+  class ConnectionBase < ActiveRecord::Base
+    def self.establish_connection(config = nil)
+      super
+      ActiveRecord::Base.connection_specification_name = connection_specification_name
+    end
+  end
+end

--- a/lib/departure/connection_base.rb
+++ b/lib/departure/connection_base.rb
@@ -1,8 +1,9 @@
 module Departure
   class ConnectionBase < ActiveRecord::Base
     def self.establish_connection(config = nil)
-      super
-      ActiveRecord::Base.connection_specification_name = connection_specification_name
+      super.tap do
+        ActiveRecord::Base.connection_specification_name = connection_specification_name
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/departurerb/departure/issues/31