### PR TITLE
Fix bug removing foreign keys with double '__' as prefix

### DIFF
--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -48,7 +48,14 @@ module ActiveRecord
 
       class SchemaCreation < ActiveRecord::ConnectionAdapters::MySQL::SchemaCreation
         def visit_DropForeignKey(name) # rubocop:disable Naming/MethodName
-          "DROP FOREIGN KEY _#{name}"
+          fk_name =
+            if name =~ /^__(.+)/
+              Regexp.last_match(1)
+            else
+              "_#{name}"
+            end
+
+          "DROP FOREIGN KEY #{fk_name}"
         end
       end
 

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -40,14 +40,32 @@ describe Departure, integration: true do
           :product_id,
           :bigint
        )
-
-      ActiveRecord::Base.connection.add_foreign_key(
-        :comments,
-        :products
-      )
     end
 
-    it 'removes a foreign key' do
+    it 'when foreign key has default name' do
+      ActiveRecord::Base.connection.add_foreign_key(:comments, :products)
+
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      expect(:comments).not_to have_foreign_key_on('product_id')
+    end
+
+    it 'when foreign key has a custom name' do
+      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "fk_123456")
+
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      expect(:comments).not_to have_foreign_key_on('product_id')
+    end
+
+    it 'when foreign key has a custom name prefixed with _' do
+      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "_fk_123456")
+
+      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      expect(:comments).not_to have_foreign_key_on('product_id')
+    end
+
+    it 'when foreign key has a custom name prefixed with __ (double _)' do
+      ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "__fk_123456")
+
       ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
     end


### PR DESCRIPTION
This fixes an error in the logic of the previous fix for foreign keys (f178ca2), the code was appending always a `_` before of foreign key name but looks like that is not how pt-online-schema-change works in all the cases.

According to pt-online-schema-change code (https://github.com/percona/percona-toolkit/blob/3.0/bin/pt-online-schema-change#L10841-L10854), is clear that `visit_DropForeignKey` should stop adding more `_` after of having two, the reason is that pt-online-schema-change drops all the `_` from the key name when copying to new table (e.g `products.__fk_name` is renamed to `_new_products.fk_name`)

Additionally, this add new specs to test the behavior of removal with multiple foreign key name patterns