### PR TITLE
Fix rubocop wrong scope warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,7 @@ Style/MultilineBlockChain:
   Exclude:
     - 'spec/integration_spec.rb'
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Enabled: false
 
 Style/SymbolArray:


### PR DESCRIPTION
# WAT

Small stuff. Rubocop warns about wrong scope for the `MultilineMethodCallIndentation` directive. Changed it to the correct scope.