### PR TITLE
Regex changes to be less strict with syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 rvm:
   - 2.2.8
+  
+services:
+  - mysql
+  
 before_install:
   - sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 8507EFA5
   - echo "deb http://repo.percona.com/apt `lsb_release -cs` main" | sudo tee -a /etc/apt/sources.list

--- a/lib/departure/alter_argument.rb
+++ b/lib/departure/alter_argument.rb
@@ -17,13 +17,12 @@ module Departure
 
       match = statement.match(ALTER_TABLE_REGEX)
       raise InvalidAlterStatement unless match
-      
       # Separates the ALTER TABLE from the table_name
       #
       # Removes the grave marks, if they are there, so we can get the table_name
       @table_name = String(match)
-                      .split(" ")[2]
-                      .gsub('`','')
+                      .split(' ')[2]
+                      .delete('`')
     end
 
     # Returns the '--alter' pt-online-schema-change argument as a string. See

--- a/lib/departure/alter_argument.rb
+++ b/lib/departure/alter_argument.rb
@@ -4,7 +4,7 @@ module Departure
   # Represents the '--alter' argument of Percona's pt-online-schema-change
   # See https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html
   class AlterArgument
-    ALTER_TABLE_REGEX = /\AALTER TABLE [^\s]+ /
+    ALTER_TABLE_REGEX = /\AALTER TABLE [^\s]*[\n]* /
 
     attr_reader :table_name
 
@@ -17,8 +17,13 @@ module Departure
 
       match = statement.match(ALTER_TABLE_REGEX)
       raise InvalidAlterStatement unless match
-
-      @table_name = match.captures[0]
+      
+      # Separates the ALTER TABLE from the table_name
+      #
+      # Removes the grave marks, if they are there, so we can get the table_name
+      @table_name = String(match)
+                      .split(" ")[2]
+                      .gsub('`','')
     end
 
     # Returns the '--alter' pt-online-schema-change argument as a string. See
@@ -38,7 +43,7 @@ module Departure
       @parsed_statement ||= statement
         .gsub(ALTER_TABLE_REGEX, '')
         .gsub('`', '\\\`')
-        .gsub(/\r?\n/, ' ')
+        .gsub(/\\n/, '')
     end
   end
 end

--- a/lib/departure/alter_argument.rb
+++ b/lib/departure/alter_argument.rb
@@ -42,7 +42,7 @@ module Departure
       @parsed_statement ||= statement
         .gsub(ALTER_TABLE_REGEX, '')
         .gsub('`', '\\\`')
-        .gsub(/\\n/, '')
+        .delete(/\\n/)
     end
   end
 end

--- a/lib/departure/alter_argument.rb
+++ b/lib/departure/alter_argument.rb
@@ -42,7 +42,7 @@ module Departure
       @parsed_statement ||= statement
         .gsub(ALTER_TABLE_REGEX, '')
         .gsub('`', '\\\`')
-        .delete(/\\n/)
+        .gsub(/\\n/, '')
     end
   end
 end

--- a/lib/departure/alter_argument.rb
+++ b/lib/departure/alter_argument.rb
@@ -4,7 +4,7 @@ module Departure
   # Represents the '--alter' argument of Percona's pt-online-schema-change
   # See https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html
   class AlterArgument
-    ALTER_TABLE_REGEX = /\AALTER TABLE `(\w+)` /
+    ALTER_TABLE_REGEX = /\AALTER TABLE [^\s]+ /
 
     attr_reader :table_name
 
@@ -38,6 +38,7 @@ module Departure
       @parsed_statement ||= statement
         .gsub(ALTER_TABLE_REGEX, '')
         .gsub('`', '\\\`')
+        .gsub(/\r?\n/, ' ')
     end
   end
 end

--- a/spec/departure/alter_argument_spec.rb
+++ b/spec/departure/alter_argument_spec.rb
@@ -22,6 +22,7 @@ describe Departure::AlterArgument do
 
     context 'when there is an ALTER TABLE present' do
       let(:statement) do
+        print(:statement)
         'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
       end
 
@@ -31,15 +32,54 @@ describe Departure::AlterArgument do
         )
       end
     end
-  end
 
-  describe '#table_name' do
-    subject { alter_argument.table_name }
+    context 'when there is an ALTER TABLE, with one line feed, present' do
+      let(:statement) do
+        print(:statement)
+        'ALTER TABLE comments\n CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      end
 
-    let(:statement) do
-      'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      it do
+        is_expected.to(
+          eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"')
+        )
+      end
     end
 
-    it { is_expected.to eq('comments') }
+    context 'when there is an ALTER TABLE, several with line feeds, present and grave marks' do
+      let(:statement) do
+        print(:statement)
+        'ALTER TABLE `comments`\n CHANGE\n `some_id` `some_id`\n INT(11) DEFAULT NULL'
+      end
+
+      it do
+        is_expected.to(
+          eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"')
+        )
+      end
+    end
+
+  end
+
+  context "when there ARE grave marks wrapping the table name" do
+    describe '#table_name' do
+      subject { alter_argument.table_name }
+
+      let(:statement) do
+        'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      end
+      it { is_expected.to eq('comments') }
+    end
+  end
+
+  context "when there ARE NO grave marks wrapping the table name" do
+    describe '#table_name' do
+      subject { alter_argument.table_name }
+
+      let(:statement) do
+        'ALTER TABLE foo CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      end
+      it { is_expected.to eq('foo') }
+    end
   end
 end


### PR DESCRIPTION
The previous regex required that the SQL generated include `'s around ids, which makes the parse fragile.  I changed the parse to look for any non-whitespace string after the ALTER TABLE.  This will support ALTER TABLE `foo` and ALTER TABLE foo , now.

I have also added an additional sub to the parsed_statement, for users utilizing strip_heredoc (has \n in the SQL) instead of squish (flattens the SQL), again, so this parser is less fragile.