### PR TITLE
Add Rails 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: ruby
+
 rvm:
-  - 2.4.6
   - 2.5.5
   - 2.6.3
   - 2.7.0
+
+env:
+  - RAILS_VERSION="~> 6.0.0"
+  - RAILS_VERSION="~> 5.2.0"
+
+jobs:
+  include:
+    - rvm: 2.4.6
+      env: RAILS_VERSION="~> 5.2.0"
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: ruby
 rvm:
-  - 2.2.8
-  
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
+  - 2.7.0
+
 services:
   - mysql
-  
+
 before_install:
-  - sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 8507EFA5
+  - travis_retry sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 8507EFA5
   - echo "deb http://repo.percona.com/apt `lsb_release -cs` main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
   - sudo apt-get install percona-toolkit

--- a/departure.gemspec
+++ b/departure.gemspec
@@ -5,6 +5,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'departure/version'
 
+# This environment variable is set on CI to facilitate testing with multiple
+# versions of Rails.
+RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '< 6.1'])
+
 Gem::Specification.new do |spec|
   spec.name          = 'departure'
   spec.version       = Departure::VERSION
@@ -19,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'railties', '~> 5.2.0'
-  spec.add_runtime_dependency 'activerecord', '~> 5.2.0'
+  spec.add_runtime_dependency 'railties', *Array(RAILS_DEPENDENCY_VERSION)
+  spec.add_runtime_dependency 'activerecord', *Array(RAILS_DEPENDENCY_VERSION)
   spec.add_runtime_dependency 'mysql2', '>= 0.4.0', '<= 0.5.3'
 
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -147,6 +147,16 @@ module ActiveRecord
       def error_number(_exception); end
 
       def full_version
+        if ActiveRecord::VERSION::MAJOR < 6
+          get_full_version
+        else
+          schema_cache.database_version.full_version_string
+        end
+      end
+
+      # This is a method defined in Rails 6.0, and we have no control over the
+      # naming of this method.
+      def get_full_version # rubocop:disable Naming/AccessorMethodName
         mysql_adapter.raw_connection.server_info[:version]
       end
 

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -20,7 +20,11 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
     let(:collation) { double(:collation) }
 
     let(:column) do
-      described_class.new(field, default, mysql_metadata, type, null, collation)
+      if ActiveRecord::VERSION::MAJOR < 6
+        described_class.new(field, default, mysql_metadata, type, null, collation)
+      else
+        described_class.new(field, default, mysql_metadata, null, collation: collation)
+      end
     end
 
     describe '#adapter' do

--- a/spec/integration/change_table_spec.rb
+++ b/spec/integration/change_table_spec.rb
@@ -4,7 +4,7 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations.select do |m|
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration).migrations.select do |m|
       m.version == version
     end
   end
@@ -19,7 +19,7 @@ describe Departure, integration: true do
 
     context 'creating column' do
       before(:each) do
-        ActiveRecord::Migrator.new(direction, migration_fixtures, version).migrate
+        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, version).migrate
       end
 
       it 'adds the column in the DB table' do

--- a/spec/integration/columns_spec.rb
+++ b/spec/integration/columns_spec.rb
@@ -4,7 +4,7 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration).migrations
   end
   let(:migration_paths) { [MIGRATION_FIXTURES] }
 
@@ -20,6 +20,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version
         ).migrate
 
@@ -30,6 +31,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version
         ).migrate
 
@@ -41,13 +43,14 @@ describe Departure, integration: true do
       let(:direction) { :down }
 
       before do
-        ActiveRecord::Migrator.new(:up, migration_fixtures, version).migrate
+        ActiveRecord::Migrator.new(:up, migration_fixtures, ActiveRecord::SchemaMigration, version).migrate
       end
 
       it 'drops the column from the DB table' do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version - 1
         ).migrate
 
@@ -58,6 +61,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version - 1
         ).migrate
 
@@ -78,12 +82,12 @@ describe Departure, integration: true do
       end
 
       it 'changes the column name' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).to have_column('new_id_field')
       end
 
       it 'does not keep the old column' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).not_to have_column('some_id_field')
       end
     end
@@ -96,19 +100,19 @@ describe Departure, integration: true do
     end
 
     before do
-      ActiveRecord::Migrator.new(:up, migration_fixtures, 1).migrate
+      ActiveRecord::Migrator.new(:up, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
     end
 
     context 'when null is true' do
       let(:version) { 14 }
 
       it 'sets the column to allow nulls' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(column.null).to be_truthy
       end
 
       it 'marks the migration as up' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
     end
@@ -117,12 +121,12 @@ describe Departure, integration: true do
       let(:version) { 15 }
 
       it 'sets the column not to allow nulls' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(column.null).to be_falsey
       end
 
       it 'marks the migration as up' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
     end
@@ -132,12 +136,12 @@ describe Departure, integration: true do
     let(:version) { 22 }
 
     it 'adds a created_at column' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).to have_column('created_at')
     end
 
     it 'adds a updated_at column' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).to have_column('updated_at')
     end
   end
@@ -154,12 +158,12 @@ describe Departure, integration: true do
     end
 
     it 'removes the created_at column' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_column('created_at')
     end
 
     it 'removes the updated_at column' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_column('updated_at')
     end
   end

--- a/spec/integration/data_migrations_spec.rb
+++ b/spec/integration/data_migrations_spec.rb
@@ -25,7 +25,7 @@ describe Departure, integration: true do
     let(:version) { 9 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures).run(
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
         direction,
         version
       )
@@ -34,7 +34,7 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures).run(
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
         direction,
         version
       )
@@ -47,7 +47,7 @@ describe Departure, integration: true do
     let(:version) { 10 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures).run(
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
         direction,
         version
       )
@@ -56,7 +56,7 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures).run(
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
         direction,
         version
       )
@@ -69,7 +69,7 @@ describe Departure, integration: true do
     let(:version) { 11 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures).run(
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
         direction,
         version
       )
@@ -78,7 +78,7 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures).run(
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
         direction,
         version
       )
@@ -91,7 +91,7 @@ describe Departure, integration: true do
     let(:version) { 12 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures).run(
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
         direction,
         version
       )
@@ -100,7 +100,7 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures).run(
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
         direction,
         version
       )

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -4,7 +4,7 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration).migrations
   end
   let(:migration_paths) { [MIGRATION_FIXTURES] }
 
@@ -24,7 +24,7 @@ describe Departure, integration: true do
     end
 
     it 'adds a foreign key' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).to have_foreign_key_on('product_id')
     end
   end
@@ -45,28 +45,28 @@ describe Departure, integration: true do
     it 'when foreign key has default name' do
       ActiveRecord::Base.connection.add_foreign_key(:comments, :products)
 
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
     end
 
     it 'when foreign key has a custom name' do
       ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "fk_123456")
 
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
     end
 
     it 'when foreign key has a custom name prefixed with _' do
       ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "_fk_123456")
 
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
     end
 
     it 'when foreign key has a custom name prefixed with __ (double _)' do
       ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "__fk_123456")
 
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
     end
   end

--- a/spec/integration/indexes_spec.rb
+++ b/spec/integration/indexes_spec.rb
@@ -4,7 +4,7 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration).migrations
   end
 
   let(:migration_paths) { [MIGRATION_FIXTURES] }
@@ -22,6 +22,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           1
         ).migrate
       end
@@ -30,6 +31,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version
         ).migrate
 
@@ -40,6 +42,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version
         ).migrate
 
@@ -54,12 +57,14 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           :up,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           1
         ).migrate
 
         ActiveRecord::Migrator.new(
           :up,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version
         ).migrate
       end
@@ -68,6 +73,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version - 1
         ).migrate
 
@@ -78,6 +84,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
+          ActiveRecord::SchemaMigration,
           version - 1
         ).migrate
 
@@ -90,16 +97,16 @@ describe Departure, integration: true do
       let(:version) { 13 }
 
       before do
-        ActiveRecord::Migrator.new(:up, migration_fixtures, 2).migrate
+        ActiveRecord::Migrator.new(:up, migration_fixtures, ActiveRecord::SchemaMigration, 2).migrate
       end
 
       it 'executes the percona command' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).to have_index('new_index_comments_on_some_id_field')
       end
 
       it 'marks the migration as down' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
     end
@@ -112,18 +119,18 @@ describe Departure, integration: true do
       let(:direction) { :up }
 
       before do
-        ActiveRecord::Migrator.new(:up, migration_fixtures, 1).migrate
+        ActiveRecord::Migrator.new(:up, migration_fixtures, ActiveRecord::SchemaMigration,1).migrate
       end
 
       it 'executes the percona command' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
 
         expect(unique_indexes_from(:comments))
           .to match_array(['index_comments_on_some_id_field'])
       end
 
       it 'marks the migration as up' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
     end
@@ -132,19 +139,19 @@ describe Departure, integration: true do
       let(:direction) { :down }
 
       before do
-        ActiveRecord::MigrationContext.new(migration_paths).run(:up, 1)
-        ActiveRecord::MigrationContext.new(migration_paths).run(:up, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(:up, 1)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(:up, version)
       end
 
       it 'executes the percona command' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
 
         expect(unique_indexes_from(:comments))
           .not_to match_array(['index_comments_on_some_id_field'])
       end
 
       it 'marks the migration as down' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(1)
       end
     end

--- a/spec/integration/references_spec.rb
+++ b/spec/integration/references_spec.rb
@@ -11,7 +11,7 @@ describe Departure, integration: true do
       let(:version) { 16 }
 
       it 'adds a reference column' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).to have_column('user_id')
       end
     end
@@ -20,12 +20,12 @@ describe Departure, integration: true do
       let(:version) { 17 }
 
       it 'adds a column for the id' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).to have_column('user_id')
       end
 
       it 'adds a column for the type' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).to have_column('user_type')
       end
 
@@ -33,7 +33,7 @@ describe Departure, integration: true do
         let(:version) { 19 }
 
         it 'adds a compound index for both the id and type columns' do
-          ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+          ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
           expect(:comments)
             .to have_index('index_comments_on_user_type_and_user_id')
         end
@@ -44,7 +44,7 @@ describe Departure, integration: true do
       let(:version) { 18 }
 
       it 'adds an index for the reference column' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
 
         expect(:comments).to have_index('index_comments_on_user_id')
       end
@@ -54,23 +54,23 @@ describe Departure, integration: true do
   context 'removing references' do
     let(:version) { 20 }
 
-    before { ActiveRecord::MigrationContext.new(migration_paths).run(direction, 16) }
+    before { ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, 16) }
 
     context 'when no option is set' do
       it 'removes the reference column' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).not_to have_column('user_id')
       end
     end
 
     context 'when polymorphic is set to true' do
       it 'removes the reference id column' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).not_to have_column('user_id')
       end
 
       it 'removes the reference type column' do
-        ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).not_to have_column('user_type')
       end
     end

--- a/spec/integration/tables_spec.rb
+++ b/spec/integration/tables_spec.rb
@@ -10,12 +10,12 @@ describe Departure, integration: true do
     let(:version) { 8 }
 
     it 'creates the table' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(tables).to include('things')
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(ActiveRecord::Migrator.current_version).to eq(version)
     end
   end
@@ -25,12 +25,12 @@ describe Departure, integration: true do
     let(:direction) { :down }
 
     it 'drops the table' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(tables).not_to include('things')
     end
 
     it 'updates the schema_migrations' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(ActiveRecord::Migrator.current_version).to eq(0)
     end
   end
@@ -39,22 +39,22 @@ describe Departure, integration: true do
     let(:version) { 24 }
 
     before do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, 1)
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, 2)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, 1)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, 2)
     end
 
     it 'changes the table name' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(tables).to include('new_comments')
     end
 
     it 'does not keep the old name' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(tables).not_to include('comments')
     end
 
     it 'changes the index names in the new table' do
-      ActiveRecord::MigrationContext.new(migration_paths).run(direction, version)
+      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:new_comments).to have_index('index_new_comments_on_some_id_field')
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -5,7 +5,7 @@ describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
   let(:migration_fixtures) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES]).migrations
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration).migrations
   end
 
   let(:direction) { :up }
@@ -25,7 +25,7 @@ describe Departure, integration: true do
 
       it "doesn't send the output to stdout" do
         expect do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
         end.to_not output.to_stdout
       end
     end
@@ -40,7 +40,7 @@ describe Departure, integration: true do
 
       it 'sends the output to stdout' do
         expect do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
         end.to output.to_stdout
       end
     end
@@ -50,7 +50,7 @@ describe Departure, integration: true do
     let(:db_config) { Configuration.new }
 
     it 'reconnects to the database using PerconaAdapter' do
-      ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+      ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
       expect(ActiveRecord::Base.connection_pool.spec.config[:adapter])
         .to eq('percona')
     end
@@ -67,7 +67,7 @@ describe Departure, integration: true do
       end
 
       it 'uses the provided username' do
-        ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
         expect(ActiveRecord::Base.connection_pool.spec.config[:username])
           .to eq('root')
       end
@@ -84,7 +84,7 @@ describe Departure, integration: true do
       end
 
       it 'uses root' do
-        ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
         expect(ActiveRecord::Base.connection_pool.spec.config[:username])
           .to eq('root')
       end
@@ -95,14 +95,14 @@ describe Departure, integration: true do
       xit 'patches it to use regular Rails migration methods' do
         expect(Departure::Lhm::Fake::Adapter)
           .to receive(:new).and_return(true)
-        ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
       end
     end
 
     context 'when there is no LHM' do
       xit 'does not patch it' do
         expect(Departure::Lhm::Fake).not_to receive(:patching_lhm)
-        ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
       end
     end
   end
@@ -115,7 +115,7 @@ describe Departure, integration: true do
 
       it 'raises and halts the execution' do
         expect do
-          ActiveRecord::Migrator.run(direction, migration_fixtures, version)
+          ActiveRecord::Migrator.run(direction, migration_fixtures, ActiveRecord::SchemaMigration, version)
         end.to raise_error do |exception|
           exception.cause == ActiveRecord::StatementInvalid
         end
@@ -132,7 +132,7 @@ describe Departure, integration: true do
 
       it 'raises and halts the execution' do
         expect do
-          ActiveRecord::Migrator.run(direction, migration_fixtures, version)
+          ActiveRecord::Migrator.run(direction, migration_fixtures, ActiveRecord::SchemaMigration, version)
         end.to raise_error do |exception|
           exception.cause == Departure::SignalError
         end
@@ -146,7 +146,7 @@ describe Departure, integration: true do
     it 'raises and halts the execution' do
       expect do
         ClimateControl.modify PATH: '' do
-          ActiveRecord::Migrator.run(direction, migration_fixtures, version)
+          ActiveRecord::Migrator.run(direction, migration_fixtures, ActiveRecord::SchemaMigration, version)
         end
       end.to raise_error do |exception|
         exception.cause == Departure::CommandNotFoundError
@@ -168,7 +168,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--chunk-time=1' do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
         end
       end
     end
@@ -181,7 +181,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--chunk-time=1 --max-lag=2' do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
         end
       end
     end
@@ -194,7 +194,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--alter-foreign-keys-method=drop_swap' do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, 1).migrate
+          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
         end
       end
     end

--- a/spec/lhm_integration_spec.rb
+++ b/spec/lhm_integration_spec.rb
@@ -18,6 +18,7 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(
           direction,
           [migration_fixtures],
+          ActiveRecord::SchemaMigration,
           version
         ).migrate
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,3 +54,27 @@ RSpec.configure do |config|
 
   Kernel.srand config.seed
 end
+
+# This shim is for Rails 5.2 compatibility in the test
+module Rails5Compatibility
+  module Migrator
+    def initialize(direction, migrations, schema_migration_or_target_version = nil, target_version = nil)
+      if schema_migration_or_target_version == ActiveRecord::SchemaMigration
+        super(direction, migrations, target_version)
+      else
+        super(direction, migrations, schema_migration_or_target_version)
+      end
+    end
+  end
+
+  module MigrationContext
+    def initialize(migrations_paths, schema_migration = nil)
+      super(migrations_paths)
+    end
+  end
+end
+
+if ActiveRecord::VERSION::MAJOR < 6
+  ActiveRecord::Migrator.send :prepend, Rails5Compatibility::Migrator
+  ActiveRecord::MigrationContext.send :prepend, Rails5Compatibility::MigrationContext
+end


### PR DESCRIPTION
This PR includes a few changes to make departure works on Rails 6.0, and also updating build matrix to include all [currently maintained Ruby versions](https://www.ruby-lang.org/en/downloads/branches/) and testing against Rails 5.2 and Rails 6.

The fix for Rails 6 is actually just 85860c65ec676d079d44fabe1fbe905828de539f. However, I felt like it's necessary for us to make sure Departure still works on Rails 5.2, and so I updated gemspec and Travis so we'd run our spec against Rails 6.0 and Rails 5.2. I also took a liberty to remove Ruby 2.2 as it's already EOL and instead include [all versions of Rubies that currently being maintained](https://www.ruby-lang.org/en/downloads/branches/).

Note that one of the change that is necessary to get the spec passing is to change how we initialize `ActiveRecord::Migrator` and `ActiveRecord::MigrationContext`, as those classes now requires us to pass a schema migration class. I've decided to update all spec to use a new method signature, and create a shim which calls the original initializer without schema migration attribute. I did it this way so that we can just remove the shim when we decide to drop Rails 5.2 support.

Please also note that the gemspec change also change this gem to support Rails >= 5.2.0 and < 6.1. I think this is safe enough to guarantee that Departure will work with any version of Rails between those two versions.

Please let me know if you have any feedback, or I should change anything to get this PR merged. Thank you very much.