### PR TITLE
Make sure quotes in ALTER TABLE get correctly escaped

### DIFF
--- a/lib/departure/alter_argument.rb
+++ b/lib/departure/alter_argument.rb
@@ -43,6 +43,7 @@ module Departure
         .gsub(ALTER_TABLE_REGEX, '')
         .gsub('`', '\\\`')
         .gsub(/\\n/, '')
+        .gsub('"', '\\\"')
     end
   end
 end

--- a/spec/departure/alter_argument_spec.rb
+++ b/spec/departure/alter_argument_spec.rb
@@ -1,85 +1,46 @@
 require 'spec_helper'
 
 describe Departure::AlterArgument do
-  let(:alter_argument) { described_class.new(statement) }
-
   describe '#initialize' do
-    subject { described_class.new(statement) }
-
-    context 'when the statement is invalid' do
-      let(:statement) { 'CREATE TABLE `things`' }
-
-      it 'raises a InvalidAlterStatement' do
-        expect { described_class.new(statement) }.to(
-          raise_error(Departure::InvalidAlterStatement)
-        )
-      end
+    it 'raises an InvalidAlterStatement if the statement is invalid' do
+      statement = 'CREATE TABLE `things`'
+      expect { described_class.new(statement) }.to(
+        raise_error(Departure::InvalidAlterStatement)
+      )
     end
   end
 
   describe '#to_s' do
-    subject { alter_argument.to_s }
-
-    context 'when there is an ALTER TABLE present' do
-      let(:statement) do
-        print(:statement)
-        'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
-      end
-
-      it do
-        is_expected.to(
-          eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"')
-        )
-      end
+    it 'outputs the --alter argument when there is an ALTER TABLE present' do
+      statement = 'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      subject = described_class.new(statement)
+      expect(subject.to_s).to eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"')
     end
 
-    context 'when there is an ALTER TABLE, with one line feed, present' do
-      let(:statement) do
-        print(:statement)
-        'ALTER TABLE comments\n CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
-      end
-
-      it do
-        is_expected.to(
-          eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"')
-        )
-      end
+    it 'escapes double quotes in the --alter argument' do
+      statement = 'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL COMMENT \'a"quote\''
+      subject = described_class.new(statement)
+      expect(subject.to_s).to eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL COMMENT \'a\\"quote\'"')
     end
 
-    context 'when there is an ALTER TABLE, several with line feeds, present and grave marks' do
-      let(:statement) do
-        print(:statement)
-        'ALTER TABLE `comments`\n CHANGE\n `some_id` `some_id`\n INT(11) DEFAULT NULL'
-      end
-
-      it do
-        is_expected.to(
-          eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"')
-        )
-      end
-    end
-
-  end
-
-  context "when there ARE grave marks wrapping the table name" do
-    describe '#table_name' do
-      subject { alter_argument.table_name }
-
-      let(:statement) do
-        'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
-      end
-      it { is_expected.to eq('comments') }
+    it 'removes "\n" character groups which otherwise would transform into line feeds and terminate the shell input' do
+      statement = 'ALTER TABLE `comments`\n CHANGE\n `some_id` `some_id`\n INT(11) DEFAULT NULL'
+      subject = described_class.new(statement)
+      expect(subject.to_s).to eq('--alter "CHANGE \`some_id\` \`some_id\` INT(11) DEFAULT NULL"')
     end
   end
 
-  context "when there ARE NO grave marks wrapping the table name" do
-    describe '#table_name' do
-      subject { alter_argument.table_name }
+  describe '#table_name' do
+    it 'returns the name of the altered table, even if the table name includes grave marks' do
+      statement = 'ALTER TABLE `comments` CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      alter_argument = described_class.new(statement)
+      expect(alter_argument.table_name).to eq('comments')
+    end
 
-      let(:statement) do
-        'ALTER TABLE foo CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
-      end
-      it { is_expected.to eq('foo') }
+    it 'returns the name of the altered table, if the table name does not include grave marks' do
+      statement = 'ALTER TABLE comments CHANGE `some_id` `some_id` INT(11) DEFAULT NULL'
+      alter_argument = described_class.new(statement)
+      expect(alter_argument.table_name).to eq('comments')
     end
   end
 end


### PR DESCRIPTION
Because of quotes used for passing the command, if a default value for a column or a value for a column comment would include a double quote the quote would be stripped. The end result would be that the value would lose quotes and an incorrect comment or default value would be set.

This adds the double quote as one of the escapes.