### PR TITLE
Relax mysql2 requirement to allow mysql2 0.5.3 gem

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'railties', '~> 5.2.0'
   spec.add_runtime_dependency 'activerecord', '~> 5.2.0'
-  spec.add_runtime_dependency 'mysql2', '>= 0.4.0', '<= 0.5.2'
+  spec.add_runtime_dependency 'mysql2', '>= 0.4.0', '<= 0.5.3'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'


### PR DESCRIPTION
It seems like departure has a strict `'>= 0.4.0', '<= 0.5.2'` mysql2 version lock since #35. 

This PR changes the requirement to allow version 0.5.3 since mysql2 0.5.3 has been [out since November 2019](https://rubygems.org/gems/mysql2/versions/0.5.3).

I tested this locally and the test case still passes, so I think this should be good to go.