### PR TITLE
Add offline migration option

### DIFF
--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -33,6 +33,22 @@ module Departure
   # Hooks Percona Migrator into Rails migrations by replacing the configured
   # database adapter
   def self.load
+    ActiveRecord::Migration.instance_eval do
+      def migrate_offline
+        self.class_eval do
+          def migrate(direction)
+            reconnect_with_default
+
+            original_migrate(direction)
+          end
+
+          def reconnect_with_default
+            Departure::ConnectionBase.establish_connection
+          end
+        end
+      end
+    end
+
     ActiveRecord::Migration.class_eval do
       alias_method :original_migrate, :migrate
 

--- a/spec/fixtures/migrate/0029_migrate_offline.rb
+++ b/spec/fixtures/migrate/0029_migrate_offline.rb
@@ -1,0 +1,9 @@
+class MigrateOffline < ActiveRecord::Migration[5.1]
+  migrate_offline
+
+  def change
+    change_table :comments do |t|
+      t.column :offline_migration_change, :integer
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -105,6 +105,28 @@ describe Departure, integration: true do
         ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
       end
     end
+
+    context 'when migrate_offline is called' do
+      before do
+        Departure.load
+        ActiveRecord::Base.establish_connection(
+            adapter: 'mysql2',
+            host: db_config['hostname'],
+            username: db_config['username'],
+            password: db_config['password'],
+            database: db_config['database']
+        )
+      end
+
+      let(:version) { 29 }
+      let(:migration_paths) { [MIGRATION_FIXTURES] }
+
+      it 'runs with the default adapter' do
+        ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
+        expect(ActiveRecord::Base.connection_pool.spec.config[:adapter])
+            .to eq('mysql2')
+      end
+    end
   end
 
   context 'when the migration failed' do


### PR DESCRIPTION
Co-authored-by: Brent Sondgeroth <bgaither@mavenlink.com>
Co-authored-by: Nate Perry <nperry@mavenlink.com>

We have found that there are several legacy migrations in our codebase that are incompatible with percona. We are fairly certain that this is a common problem for legacy codebases that try to use `departure`. Our solution is to add an offline mode that will run the migration with the default adapter. This `migrate_offline` can be added to old migrations so that they succeed when migrating from a new DB.

This has the additional benefit that new migrations of smaller tables can be run offline w/o the overhead of percona.

We understand that a viable work around would be to use `bundle exec rails db:schema:load`. However we think adding an option to skip percona helps enable better continuous delivery practices.

We are struggling with writing a spec for the current changes, and would appreciate any help.
