### PR TITLE
Allow Departure to be disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,23 @@ end
 It's strongly recommended to name it after this gems name, such as
 `config/initializers/departure.rb`
 
+### Only enabled on a per-migration basis
+
+If you wish to only have Departure enabled per-migration, set `config.enabled_by_default = false` in the configure block of your departure initializer.
+
+Then, add a `uses_departure!` statement in migrations where Departure should be used:
+
+```ruby
+class UseDepartureMigration < ActiveRecord::Migration[5.2]
+  uses_departure!
+
+  def up
+    # ...
+  end
+  # ...
+end
+```
+
 ## How it works
 
 When booting your Rails app, Departure extends the

--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -14,6 +14,7 @@ require 'departure/configuration'
 require 'departure/errors'
 require 'departure/command'
 require 'departure/connection_base'
+require 'departure/migration'
 
 require 'departure/railtie' if defined?(Rails)
 
@@ -30,40 +31,9 @@ module Departure
     yield(configuration)
   end
 
-  # Hooks Percona Migrator into Rails migrations by replacing the configured
-  # database adapter
   def self.load
     ActiveRecord::Migration.class_eval do
-      alias_method :original_migrate, :migrate
-
-      # Replaces the current connection adapter with the PerconaAdapter and
-      # patches LHM, then it continues with the regular migration process.
-      #
-      # @param direction [Symbol] :up or :down
-      def migrate(direction)
-        reconnect_with_percona
-        include_foreigner if defined?(Foreigner)
-
-        ::Lhm.migration = self
-        original_migrate(direction)
-      end
-
-      # Includes the Foreigner's Mysql2Adapter implemention in
-      # DepartureAdapter to support foreign keys
-      def include_foreigner
-        Foreigner::Adapter.safe_include(
-          :DepartureAdapter,
-          Foreigner::ConnectionAdapters::Mysql2Adapter
-        )
-      end
-
-      # Make all connections in the connection pool to use PerconaAdapter
-      # instead of the current adapter.
-      def reconnect_with_percona
-        connection_config = ActiveRecord::Base
-          .connection_config.merge(adapter: 'percona')
-        Departure::ConnectionBase.establish_connection(connection_config)
-      end
+      include Departure::Migration
     end
   end
 end

--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -21,6 +21,12 @@ require 'departure/railtie' if defined?(Rails)
 # We need the OS not to buffer the IO to see pt-osc's output while migrating
 $stdout.sync = true
 
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Migration.class_eval do
+    include Departure::Migration
+  end
+end
+
 module Departure
   class << self
     attr_accessor :configuration
@@ -32,8 +38,6 @@ module Departure
   end
 
   def self.load
-    ActiveRecord::Migration.class_eval do
-      include Departure::Migration
-    end
+    # No-op left for compatibility
   end
 end

--- a/lib/departure/configuration.rb
+++ b/lib/departure/configuration.rb
@@ -1,11 +1,12 @@
 module Departure
   class Configuration
-    attr_accessor :tmp_path, :global_percona_args
+    attr_accessor :tmp_path, :global_percona_args, :enabled_by_default
 
     def initialize
       @tmp_path = '.'.freeze
       @error_log_filename = 'departure_error.log'.freeze
       @global_percona_args = nil
+      @enabled_by_default = true
     end
 
     def error_log_path

--- a/lib/departure/migration.rb
+++ b/lib/departure/migration.rb
@@ -17,6 +17,7 @@ module Departure
       # The default for this attribute is set based on
       # Departure.configuration.enabled_by_default (default true).
       class_attribute :uses_departure
+      self.uses_departure = true
 
       alias_method :active_record_migrate, :migrate
       remove_method :migrate

--- a/lib/departure/migration.rb
+++ b/lib/departure/migration.rb
@@ -1,0 +1,79 @@
+module Departure
+  # Hooks Percona Migrator into Rails migrations by replacing the configured
+  # database adapter
+  module Migration
+    extend ActiveSupport::Concern
+
+    included do
+      # Holds the name of the adapter that was configured by the app.
+      mattr_accessor :original_adapter
+      self.original_adapter = ActiveRecord::Base.connection_config[:adapter]
+
+      # Declare on a per-migration class basis whether or not to use Departure.
+      # The default for this attribute is set based on
+      # Departure.configuration.enabled_by_default (default true).
+      class_attribute :uses_departure
+
+      alias_method :active_record_migrate :migrate
+      remove_method :migrate
+    end
+
+    module ClassMethods
+      # Declare `uses_departure!` in the class body of your migration to enable
+      # Departure for that migration only when
+      # Departure.configuration.enabled_by_default is false.
+      def uses_departure!
+        self.uses_departure = true
+      end
+    end
+
+
+    # Replaces the current connection adapter with the PerconaAdapter and
+    # patches LHM, then it continues with the regular migration process.
+    #
+    # @param direction [Symbol] :up or :down
+    def departure_migrate(direction)
+      reconnect_with_percona
+      include_foreigner if defined?(Foreigner)
+
+      ::Lhm.migration = self
+      active_record_migrate(direction)
+    end
+
+    # Migrate with or without Departure based on uses_departure class
+    # attribute.
+    def migrate(direction)
+      if uses_departure?
+        departure_migrate(direction)
+      else
+        reconnect_without_percona
+        active_record_migrate(direction)
+      end
+    end
+
+    # Includes the Foreigner's Mysql2Adapter implemention in
+    # DepartureAdapter to support foreign keys
+    def include_foreigner
+      Foreigner::Adapter.safe_include(
+        :DepartureAdapter,
+        Foreigner::ConnectionAdapters::Mysql2Adapter
+      )
+    end
+
+    # Make all connections in the connection pool to use PerconaAdapter
+    # instead of the current adapter.
+    def reconnect_with_percona
+      connection_config = ActiveRecord::Base.connection_config
+      return if connection_config[:adapter] == 'percona'
+      Departure::ConnectionBase.establish_connection(connection_config.merge(adapter: 'percona'))
+    end
+
+    # Reconnect without percona adapter when Departure is disabled but was
+    # enabled in a previous migration.
+    def reconnect_without_percona
+      connection_config = ActiveRecord::Base.connection_config
+      return unless connection_config[:adapter] == 'percona'
+      Departure::ConnectionBase.establish_connection(connection_config.merge(adapter: original_adapter))
+    end
+  end
+end

--- a/lib/departure/migration.rb
+++ b/lib/departure/migration.rb
@@ -14,7 +14,7 @@ module Departure
       # Departure.configuration.enabled_by_default (default true).
       class_attribute :uses_departure
 
-      alias_method :active_record_migrate :migrate
+      alias_method :active_record_migrate, :migrate
       remove_method :migrate
     end
 

--- a/lib/departure/migration.rb
+++ b/lib/departure/migration.rb
@@ -1,6 +1,10 @@
 module Departure
   # Hooks Percona Migrator into Rails migrations by replacing the configured
   # database adapter
+  #
+  # It also patches ActiveRecord's #migrate method so that it patches LHM
+  # first. This will make migrations written with LHM to go through the
+  # regular Rails Migration DSL.
   module Migration
     extend ActiveSupport::Concern
 

--- a/lib/departure/railtie.rb
+++ b/lib/departure/railtie.rb
@@ -6,19 +6,6 @@ module Departure
   class Railtie < Rails::Railtie
     railtie_name :departure
 
-    # It drops all previous database connections and reconnects using this
-    # PerconaAdapter. By doing this, all later ActiveRecord methods called in
-    # the migration will use this adapter instead of Mysql2Adapter.
-    #
-    # It also patches ActiveRecord's #migrate method so that it patches LHM
-    # first. This will make migrations written with LHM to go through the
-    # regular Rails Migration DSL.
-    initializer 'departure.configure_rails_initialization' do
-      ActiveSupport.on_load(:active_record) do
-        Departure.load
-      end
-    end
-
     initializer 'departure.configure' do |app|
       Departure.configure do |config|
         config.tmp_path = app.paths['tmp'].first

--- a/lib/departure/railtie.rb
+++ b/lib/departure/railtie.rb
@@ -24,5 +24,11 @@ module Departure
         config.tmp_path = app.paths['tmp'].first
       end
     end
+
+    config.after_initialize do
+      Departure.configure do |dc|
+        ActiveRecord::Migration.uses_departure = dc.enabled_by_default
+      end
+    end
   end
 end

--- a/spec/departure/migration_spec.rb
+++ b/spec/departure/migration_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Departure::Migration do
+  let(:base) do
+    Class.new do
+      attr_accessor :migrated_direction
+
+      def migrate(direction)
+        self.migrated_direction = direction
+      end
+
+      include Departure::Migration
+    end
+  end
+
+  let(:klass) { Class.new(base) }
+
+  subject(:migration) { klass.new }
+
+  context 'uses_departure class attribute' do
+    it 'can set default value on base class' do
+      base.uses_departure = true
+      expect(klass.uses_departure).to eq(true)
+      expect(subject.uses_departure).to eq(true)
+    end
+
+    it 'can override on migration with uses_departure!' do
+      base.uses_departure = false
+      klass.uses_departure!
+      expect(subject.uses_departure).to eq(true)
+    end
+  end
+
+  context 'Departure enabled (uses_departure is truthy)' do
+    before { klass.uses_departure! }
+
+    it 'calls departure_migrate' do
+      expect(subject).to receive(:departure_migrate).and_call_original
+
+      subject.migrate(:up)
+
+      expect(subject.migrated_direction).to eq(:up)
+    end
+  end
+
+  context 'Departure disabled (uses_departure falsy)' do
+    before { klass.uses_departure = false }
+
+    it 'does not call departure_migrate' do
+      expect(subject).to_not receive(:departure_migrate)
+
+      subject.migrate(:up)
+
+      expect(subject.migrated_direction).to eq(:up)
+    end
+  end
+end


### PR DESCRIPTION
We recently ran into a situation where a data migration that was expecting a `RecordNotUnique` error failed instead due to a `StatementInvalidError` because of the way Departure wraps the inner mysql2 connection. This led us down the road of treating Departure like an add-on to be used in situations that require it and leave it out of the code path in the majority of situations. We ended up with a monkey patch similar to what I've put in this PR. Thought I'd throw this up for consideration to see if it's something you'd be interested in pulling into the library.

Thanks for continuing to maintain Departure, it's otherwise been extremely useful for us!