### PR TITLE
Add documentation for disabling departure on particular migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,23 @@ end
 It's strongly recommended to name it after this gems name, such as
 `config/initializers/departure.rb`
 
-### Only enabled on a per-migration basis
+### Disable on per-migration basis
+
+Departure gem is enabled by default. 
+In order to disable it on a particular migration the method `disable_departure!` should be used.
+
+```ruby
+class UseDepartureMigration < ActiveRecord::Migration[5.2]
+  disable_departure!
+
+  def up
+    # ...
+  end
+  # ...
+end
+```
+
+### Enable on per-migration basis
 
 If you wish to only have Departure enabled per-migration, set `config.enabled_by_default = false` in the configure block of your departure initializer.
 


### PR DESCRIPTION
The functionality to disable the non-blocking DDL is useful on certain migrations that don't need it. I added documentation for the `disable_departure!` method so is easier to find.