### PR TITLE
Relax Rails dependency version

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -7,7 +7,7 @@ require 'departure/version'
 
 # This environment variable is set on CI to facilitate testing with multiple
 # versions of Rails.
-RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '<= 6.1'])
+RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '< 6.2'])
 
 Gem::Specification.new do |spec|
   spec.name          = 'departure'


### PR DESCRIPTION
Hi,

I'm trying to use departure with the latest version of ActiveRecord (6.1.3.1) but the current dependency isn't allowing it. Would it be possible to relax it ?

Thanks 🙌 