### PR TITLE
Fix problem with remove_index on Rails 6.1

### DIFF
--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -142,14 +142,14 @@ module ActiveRecord
       #
       # @param table_name [String, Symbol]
       # @param options [Hash] optional
-      def remove_index(table_name, *args, **options)
-        column_name = args.first
-        if column_name
+      def remove_index(table_name, column_name = nil, **options)
+        if ActiveRecord::VERSION::STRING >= '6.1'
           return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
           index_name = index_name_for_remove(table_name, column_name, **options)
         else
           index_name = index_name_for_remove(table_name, options)
         end
+
         execute "ALTER TABLE #{quote_table_name(table_name)} DROP INDEX #{quote_column_name(index_name)}"
       end
 

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -156,6 +156,11 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
           .with(table_name, options)
           .and_return('index_name')
         )
+        allow(adapter).to(
+          receive(:index_name_for_remove)
+          .with(table_name, nil, options)
+          .and_return('index_name')
+        )
       end
 
       it 'passes the built SQL to #execute' do


### PR DESCRIPTION
In https://github.com/departurerb/departure/pull/58, there was an attempt to make this `remove_index` method works with Rails 6.1 by receiving and passing the second argument to `index_name_for_remove` method if this second argument is set.

However, this second `column_name` argument can still be nil when user try to invoke `remove_index` with compound index, for example:

    remove_index :posts, column: %w(status user_id)

This commit fixes the issue by checking for Rails version first before calling `index_name_for_remove`.


Note that prior to this commit `master` branch is also broken after https://github.com/departurerb/departure/pull/58 was merged in, so this commit also fixing the test suite on both Rails 6.0 and 6.1.