### PR TITLE
Allow Departure to run against Edge Rails

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -7,7 +7,7 @@ require 'departure/version'
 
 # This environment variable is set on CI to facilitate testing with multiple
 # versions of Rails.
-RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '< 6.2'])
+RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '< 7.0'])
 
 Gem::Specification.new do |spec|
   spec.name          = 'departure'


### PR DESCRIPTION
This PR updates the upper bound of `RAILS_DEPENDENCY_VERSION` to allow Departure to run with Edge Rails, as Edge Rails is now targeting version 7.0: https://github.com/rails/rails/blob/1f566bd9ba0d1e657f09608b1d4140f9e11a8326/version.rb

Note that this will still block Departure to run with Rails 7.0.0 final when it comes out. Hence, we'll still have time to check the compatibility before saying that Departure works with Rails 7.0.0.