### PR TITLE
Fix broken test in command_spec

### DIFF
--- a/spec/departure/command_spec.rb
+++ b/spec/departure/command_spec.rb
@@ -64,7 +64,7 @@ describe Departure::Command do
     end
 
     context 'when not redirecting stderr' do
-      let(:expected_command) { command }
+      let(:expected_command) { "#{command} 2>&1" }
       let(:redirect_stderr) { false }
 
       it 'executes the expected command' do


### PR DESCRIPTION
This PR fixes a broken test in `master` branch:

```
Failures:

  1) Departure::Command#run when not redirecting stderr executes the expected command
     Failure/Error:
       Open3.popen3(full_command) do |_stdin, stdout, _stderr, waith_thr|
         begin
           loop do
             IO.select([stdout])
             data = stdout.read_nonblock(8192)
             logger.write_no_newline(data)
           end
         rescue EOFError # rubocop:disable Lint/HandleExceptions
           # noop
         ensure
     
       Open3 received :popen3 with unexpected arguments
         expected: ("pt-online-schema-change command")
              got: ("pt-online-schema-change command 2>&1")
        Please stub a default value first if message might be received with other args as well. 
     # ./lib/departure/command.rb:44:in `run_in_process'
     # ./lib/departure/command.rb:29:in `run'
     # ./spec/departure/command_spec.rb:71:in `block (4 levels) in <top (required)>'
```

I think this might have been introduced in https://github.com/departurerb/departure/pull/63. By default, if not redirecting `$stderr` to a file, we now redirect it to `$stdout`:

https://github.com/departurerb/departure/blob/0d0c4b0bf8829715bfc0ad42827228d47126adc9/lib/departure/command.rb#L63-L69

---

On a side note, I just noticed that this project was still trying to build using Travis CI. However, Travis CI ORG (which is the free service for open-source projects) [shut down back at the end of May](https://blog.travis-ci.com/2021-05-07-orgshutdown) and the green checkmark we got on the SHA is just from Code Climate.

I'll submit another PR to switch CI to GitHub Actions, as it's free for open-source projects.