### PR TITLE
Fix add_index on Rails 6.1

### DIFF
--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -129,9 +129,8 @@ module ActiveRecord
       # @param options [Hash] optional
       def add_index(table_name, column_name, options = {})
         if ActiveRecord::VERSION::STRING >= '6.1'
-          index, algorithm, if_not_exists = add_index_options(table_name, column_name, options)
-          create_index = CreateIndexDefinition.new(index, algorithm, if_not_exists)
-          execute schema_creation.accept(create_index)
+          index_definition, _ = add_index_options(table_name, column_name, options)
+          execute "ALTER TABLE #{quote_table_name(index_definition.table)} ADD #{schema_creation.accept(index_definition)}"
         else
           index_name, index_type, index_columns, index_options = add_index_options(table_name, column_name, options)
           execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} (#{index_columns})#{index_options}" # rubocop:disable Metrics/LineLength

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -129,8 +129,8 @@ module ActiveRecord
       # @param options [Hash] optional
       def add_index(table_name, column_name, options = {})
         if ActiveRecord::VERSION::STRING >= '6.1'
-          index_definition, _ = add_index_options(table_name, column_name, options)
-          execute "ALTER TABLE #{quote_table_name(index_definition.table)} ADD #{schema_creation.accept(index_definition)}"
+          index_definition, = add_index_options(table_name, column_name, options)
+          execute "ALTER TABLE #{quote_table_name(index_definition.table)} ADD #{schema_creation.accept(index_definition)}" # rubocop:disable Metrics/LineLength
         else
           index_name, index_type, index_columns, index_options = add_index_options(table_name, column_name, options)
           execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} (#{index_columns})#{index_options}" # rubocop:disable Metrics/LineLength

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -1,6 +1,7 @@
 require 'active_record/connection_adapters/abstract_mysql_adapter'
 require 'active_record/connection_adapters/statement_pool'
 require 'active_record/connection_adapters/mysql2_adapter'
+require 'active_support/core_ext/string/filters'
 require 'departure'
 require 'forwardable'
 
@@ -130,10 +131,17 @@ module ActiveRecord
       def add_index(table_name, column_name, options = {})
         if ActiveRecord::VERSION::STRING >= '6.1'
           index_definition, = add_index_options(table_name, column_name, options)
-          execute "ALTER TABLE #{quote_table_name(index_definition.table)} ADD #{schema_creation.accept(index_definition)}" # rubocop:disable Metrics/LineLength
+          execute <<-SQL.squish
+            ALTER TABLE #{quote_table_name(index_definition.table)}
+              ADD #{schema_creation.accept(index_definition)}
+          SQL
         else
           index_name, index_type, index_columns, index_options = add_index_options(table_name, column_name, options)
-          execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} (#{index_columns})#{index_options}" # rubocop:disable Metrics/LineLength
+          execute <<-SQL.squish
+            ALTER TABLE #{quote_table_name(table_name)}
+              ADD #{index_type} INDEX
+              #{quote_column_name(index_name)} (#{index_columns})#{index_options}
+          SQL
         end
       end
 

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -125,7 +125,7 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
 
       let(:expected_sql) do
         if ActiveRecord::VERSION::STRING >= '6.1'
-          "CREATE INDEX_TYPE INDEX `#{index_name}` ON `#{table_name}` (`#{column_name}`)"
+          "ALTER TABLE `#{table_name}` ADD #{index_type} INDEX `#{index_name}` (`#{column_name}`)"
         else
           "ALTER TABLE `#{table_name}` ADD #{index_type} INDEX `#{index_name}` (#{column_name})"
         end

--- a/spec/integration/indexes_spec.rb
+++ b/spec/integration/indexes_spec.rb
@@ -170,7 +170,7 @@ describe Departure, integration: true do
 
   def expect_percona_command(command)
     # Add addional escaping to backticks here to keep the spec more readable.
-    command.gsub!(/`/, '\\\`')
+    command = command.gsub(/`/, '\\\`')
 
     expect(Open3).
       to receive(:popen3).


### PR DESCRIPTION
This PR fixes the problem that `add_index` no longer uses `pt-online-schema-change` to alter the table on Rails 6.1+.

This regression was unintentionally introduced back in #58 when an update was made to make Departure works with Rails 6.1. This did not get caught by our test suite because the test suite did not really test that the command was properly shelled out to `pt-online-schema-change` or not, and only asserting the result of the operation.

This commit updates the code in `add_index` to execute query with `ALTER TABLE` instead of `CREATE INDEX`. We need to call `execute` with a SQL starting with `ALTER TABLE` for Departure to kick in and shell out to `pt-online-schema-change`.

This commit also update specs related to adding/removing index to making sure that we actually call `pt-online-schema-change` to perform the DDL operation by making sure that `Open3.popen3` has been called to prevent future accidental regression.

This fixes #61.