### PR TITLE
Rails 6.1 fixes

### DIFF
--- a/lib/active_record/connection_adapters/for_alter.rb
+++ b/lib/active_record/connection_adapters/for_alter.rb
@@ -59,8 +59,8 @@ module ForAlterStatements
     "ADD #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})#{index_algorithm}"
   end
 
-  def remove_index_for_alter(table_name, options = {})
-    index_name = index_name_for_remove(table_name, options)
+  def remove_index_for_alter(table_name, column_name, options = {})
+    index_name = index_name_for_remove(table_name, column_name, options)
     "DROP INDEX #{quote_column_name(index_name)}"
   end
 

--- a/lib/active_record/connection_adapters/for_alter.rb
+++ b/lib/active_record/connection_adapters/for_alter.rb
@@ -52,11 +52,17 @@ module ForAlterStatements
   end
 
   def add_index_for_alter(table_name, column_name, options = {})
-    index_name, index_type, index_columns, _,
-      index_algorithm, index_using = add_index_options(table_name, column_name, options)
+    if ActiveRecord::VERSION::STRING >= '6.1'
+      index_definition, = add_index_options(table_name, column_name, options)
 
-    index_algorithm[0, 0] = ', ' if index_algorithm.present?
-    "ADD #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})#{index_algorithm}"
+      "ADD #{schema_creation.accept(index_definition)}"
+    else
+      index_name, index_type, index_columns, _,
+        index_algorithm, index_using = add_index_options(table_name, column_name, options)
+      index_algorithm[0, 0] = ', ' if index_algorithm.present?
+
+      "ADD #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})#{index_algorithm}"
+    end
   end
 
   def remove_index_for_alter(table_name, column_name, options = {})

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -1,6 +1,7 @@
 require 'active_record/connection_adapters/abstract_mysql_adapter'
 require 'active_record/connection_adapters/statement_pool'
 require 'active_record/connection_adapters/mysql2_adapter'
+require 'active_support/core_ext/string/filters'
 require 'departure'
 require 'forwardable'
 
@@ -129,12 +130,18 @@ module ActiveRecord
       # @param options [Hash] optional
       def add_index(table_name, column_name, options = {})
         if ActiveRecord::VERSION::STRING >= '6.1'
-          index, algorithm, if_not_exists = add_index_options(table_name, column_name, options)
-          create_index = CreateIndexDefinition.new(index, algorithm, if_not_exists)
-          execute schema_creation.accept(create_index)
+          index_definition, = add_index_options(table_name, column_name, options)
+          execute <<-SQL.squish
+            ALTER TABLE #{quote_table_name(index_definition.table)}
+              ADD #{schema_creation.accept(index_definition)}
+          SQL
         else
           index_name, index_type, index_columns, index_options = add_index_options(table_name, column_name, options)
-          execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} (#{index_columns})#{index_options}" # rubocop:disable Metrics/LineLength
+          execute <<-SQL.squish
+            ALTER TABLE #{quote_table_name(table_name)}
+              ADD #{index_type} INDEX
+              #{quote_column_name(index_name)} (#{index_columns})#{index_options}
+          SQL
         end
       end
 

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -125,7 +125,7 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
 
       let(:expected_sql) do
         if ActiveRecord::VERSION::STRING >= '6.1'
-          "CREATE INDEX_TYPE INDEX `#{index_name}` ON `#{table_name}` (`#{column_name}`)"
+          "ALTER TABLE `#{table_name}` ADD #{index_type} INDEX `#{index_name}` (`#{column_name}`)"
         else
           "ALTER TABLE `#{table_name}` ADD #{index_type} INDEX `#{index_name}` (#{column_name})"
         end

--- a/spec/integration/indexes_spec.rb
+++ b/spec/integration/indexes_spec.rb
@@ -28,6 +28,8 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
+        expect_percona_command('ADD INDEX `index_comments_on_some_id_field` (`some_id_field`)')
+
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
@@ -70,6 +72,8 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
+        expect_percona_command('DROP INDEX `index_comments_on_some_id_field`')
+
         ActiveRecord::Migrator.new(
           direction,
           migration_fixtures,
@@ -101,11 +105,14 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
+        expect_percona_command('ADD INDEX `new_index_comments_on_some_id_field` (`some_id_field`)')
+        expect_percona_command('DROP INDEX `index_comments_on_some_id_field`')
+
         ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).to have_index('new_index_comments_on_some_id_field')
       end
 
-      it 'marks the migration as down' do
+      it 'marks the migration as up' do
         ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(ActiveRecord::Migrator.current_version).to eq(version)
       end
@@ -123,6 +130,8 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
+        expect_percona_command('ADD UNIQUE INDEX `index_comments_on_some_id_field` (`some_id_field`)')
+
         ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
 
         expect(unique_indexes_from(:comments))
@@ -144,6 +153,8 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
+        expect_percona_command('DROP INDEX `index_comments_on_some_id_field`')
+
         ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
 
         expect(unique_indexes_from(:comments))
@@ -155,5 +166,15 @@ describe Departure, integration: true do
         expect(ActiveRecord::Migrator.current_version).to eq(1)
       end
     end
+  end
+
+  def expect_percona_command(command)
+    # Add addional escaping to backticks here to keep the spec more readable.
+    command = command.gsub(/`/, '\\\`')
+
+    expect(Open3).
+      to receive(:popen3).
+      with(a_string_matching(/\Apt-online-schema-change .+--alter "#{Regexp.escape(command)}"/)).
+      and_call_original
   end
 end


### PR DESCRIPTION
The first commit is a copy of #67. The other commits fix issues with bulk add_index and remove_index operations on Rails 6.1.

Tested on Rails 6.1.4.1