### PR TITLE
Fix failing test from master

### DIFF
--- a/spec/departure/connection_details_spec.rb
+++ b/spec/departure/connection_details_spec.rb
@@ -72,8 +72,7 @@ describe Departure::ConnectionDetails do
     end
 
     context 'when the password contains bash incompatible characters' do
-      let(:env_var) { {} }
-      let(:connection_data) { { password: '!#/PASSWORD!!!' } }
+      let(:env_var) { { PERCONA_DB_PASSWORD: '!#/PASSWORD!!!' } }
       it { is_expected.to include('--password \!\#/PASSWORD\!\!\!') }
     end
   end

--- a/spec/integration/indexes_spec.rb
+++ b/spec/integration/indexes_spec.rb
@@ -105,8 +105,7 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
-        expect_percona_command('ADD INDEX `new_index_comments_on_some_id_field` (`some_id_field`)')
-        expect_percona_command('DROP INDEX `index_comments_on_some_id_field`')
+        expect_percona_command('RENAME INDEX `index_comments_on_some_id_field` TO `new_index_comments_on_some_id_field`')
 
         ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).to have_index('new_index_comments_on_some_id_field')


### PR DESCRIPTION
Change test to use rename index command
The rails rename_index command generates a `RENAME INDEX` pt-osc command
```pt-online-schema-change -h "db" -P 3306 -u root  --execute --statistics --alter-foreign-keys-method=auto --no-check-alter D=departure_test,t=comments --alter "RENAME INDEX \`index_comments_on_some_id_field\` TO \`new_index_comments_on_some_id_field\`"```