### PR TITLE
Fix failing tests on master

### DIFF
--- a/spec/departure/connection_details_spec.rb
+++ b/spec/departure/connection_details_spec.rb
@@ -72,7 +72,7 @@ describe Departure::ConnectionDetails do
     end
 
     context 'when the password contains bash incompatible characters' do
-      let(:env_var) { {} }
+      let(:env_var) { { PERCONA_DB_PASSWORD: nil } }
       let(:connection_data) { { password: '!#/PASSWORD!!!' } }
       it { is_expected.to include('--password \!\#/PASSWORD\!\!\!') }
     end

--- a/spec/integration/indexes_spec.rb
+++ b/spec/integration/indexes_spec.rb
@@ -105,8 +105,7 @@ describe Departure, integration: true do
       end
 
       it 'executes the percona command' do
-        expect_percona_command('ADD INDEX `new_index_comments_on_some_id_field` (`some_id_field`)')
-        expect_percona_command('DROP INDEX `index_comments_on_some_id_field`')
+        expect_percona_command('RENAME INDEX `index_comments_on_some_id_field` TO `new_index_comments_on_some_id_field`')
 
         ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
         expect(:comments).to have_index('new_index_comments_on_some_id_field')


### PR DESCRIPTION
This PR contains two fixes:

## Unset `PERCONA_DB_PASSWORD` in connection details spec

It turns out that GitHub Actions set `PERCONA_DB_PASSWORD` to `root` (per investigation described [here](https://github.com/departurerb/departure/pull/74#issuecomment-1013090589)). We need this value to be nil so it'll pick up the password from `connection_data[:password]` instead.

## Updates renaming index spec to support both MySQL 5.6 and newer versions.

Active Record will use `RENAME INDEX` command on MySQL version that supports `RENAME INDEX` command. Hence, we should assert for `RENAME INDEX` when `supports_rename_index?` is true. ([explaination](https://github.com/departurerb/departure/pull/74#issuecomment-1012026675))

---

Closes #74 as patches have been integrated here.