### PR TITLE
fixes bug with upsert_all

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
-require 'percona_migrator'
+require 'departure'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -96,7 +96,7 @@ module ActiveRecord
 
       def exec_query(sql, name = 'SQL', _binds = [], **_kwargs)
         result = execute(sql, name)
-        ActiveRecord::Result.new(result.fields, result.to_a)
+        ActiveRecord::Result.new(result&.fields, result.to_a)
       end
 
       # Executes a SELECT query and returns an array of rows. Each row is an

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -96,7 +96,8 @@ module ActiveRecord
 
       def exec_query(sql, name = 'SQL', _binds = [], **_kwargs)
         result = execute(sql, name)
-        ActiveRecord::Result.new(result&.fields, result.to_a)
+        fields = result.field if defined?(result.fields)
+        ActiveRecord::Result.new(fields, result.to_a)
       end
 
       # Executes a SELECT query and returns an array of rows. Each row is an

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -96,7 +96,7 @@ module ActiveRecord
 
       def exec_query(sql, name = 'SQL', _binds = [], **_kwargs)
         result = execute(sql, name)
-        fields = result.field if defined?(result.fields)
+        fields = result.fields if defined?(result.fields)
         ActiveRecord::Result.new(fields, result.to_a)
       end
 

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -214,7 +214,6 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
     let(:sql) { 'SELECT * FROM comments' }
     let(:name) { nil }
     let(:binds) { nil }
-    let(:result_set) { double(fields: [:id], to_a: [1]) }
 
     before do
       allow(runner).to receive(:query).with(sql)
@@ -223,19 +222,42 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
       )
     end
 
-    it 'executes the sql' do
-      expect(adapter).to(
-        receive(:execute).with(sql, name)
-      ).and_return(result_set)
+    context 'when the adapter returns results' do
+      let(:result_set) { double(fields: [:id], to_a: [1]) }
 
-      adapter.exec_query(sql, name, binds)
+      it 'executes the sql' do
+        expect(adapter).to(
+          receive(:execute).with(sql, name)
+        ).and_return(result_set)
+
+        adapter.exec_query(sql, name, binds)
+      end
+
+      it 'returns an ActiveRecord::Result' do
+        expect(ActiveRecord::Result).to(
+          receive(:new).with(result_set.fields, result_set.to_a)
+        )
+        adapter.exec_query(sql, name, binds)
+      end
     end
 
-    it 'returns an ActiveRecord::Result' do
-      expect(ActiveRecord::Result).to(
-        receive(:new).with(result_set.fields, result_set.to_a)
-      )
-      adapter.exec_query(sql, name, binds)
+    context 'when the adapter returns nil' do
+      let(:result_set) { nil }
+
+      it 'executes the sql' do
+        expect(adapter).to(
+          receive(:execute).with(sql, name)
+        ).and_return(result_set)
+
+        adapter.exec_query(sql, name, binds)
+      end
+
+      it 'returns an ActiveRecord::Result' do
+        expect(ActiveRecord::Result).to(
+          receive(:new).with(result_set.fields, result_set.to_a)
+        )
+        adapter.exec_query(sql, name, binds)
+      end
     end
   end
 

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -254,7 +254,7 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
 
       it 'returns an ActiveRecord::Result' do
         expect(ActiveRecord::Result).to(
-          receive(:new).with(result_set.fields, result_set.to_a)
+          receive(:new).with(nil, [])
         )
         adapter.exec_query(sql, name, binds)
       end

--- a/spec/fixtures/migrate/0030_data_migration_with_upsert_all.rb
+++ b/spec/fixtures/migrate/0030_data_migration_with_upsert_all.rb
@@ -2,8 +2,9 @@ class DataMigrationWithUpsertAll < ActiveRecord::Migration[5.1]
   def up
     add_column :comments, :author, :string
 
-    Comment.reset_column_information
+    return unless defined?(Comment.upsert_all)
 
+    Comment.reset_column_information
     Comment.upsert_all([
       { author: "John", read: true },
       { author: "Smith", read: false }

--- a/spec/fixtures/migrate/0030_data_migration_with_upsert_all.rb
+++ b/spec/fixtures/migrate/0030_data_migration_with_upsert_all.rb
@@ -1,0 +1,14 @@
+class DataMigrationWithUpsertAll < ActiveRecord::Migration[5.1]
+  def up
+    add_column :comments, :author, :string
+
+    Comment.reset_column_information
+
+    Comment.upsert_all([
+      { author: "John", read: true },
+      { author: "Smith", read: false }
+    ])
+  end
+
+  def down; end
+end

--- a/spec/integration/data_migrations_spec.rb
+++ b/spec/integration/data_migrations_spec.rb
@@ -43,7 +43,7 @@ describe Departure, integration: true do
     end
   end
 
-  context 'running a migration with .upsert_all' do
+  context 'running a migration with .upsert_all', if: defined?(Comment.upsert_all) do
     let(:version) { 30 }
 
     it 'updates all the required data' do

--- a/spec/integration/data_migrations_spec.rb
+++ b/spec/integration/data_migrations_spec.rb
@@ -43,6 +43,33 @@ describe Departure, integration: true do
     end
   end
 
+  context 'running a migration with .upsert_all' do
+    let(:version) { 30 }
+
+    it 'updates all the required data' do
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
+        direction,
+        version
+      )
+
+      expect(Comment.pluck(:author, :read)).to match_array([
+        [nil, false],
+        [nil, false],
+        ["John", true],
+        ["Smith", false],
+      ])
+    end
+
+    it 'marks the migration as up' do
+      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
+        direction,
+        version
+      )
+
+      expect(ActiveRecord::Migrator.current_version).to eq(version)
+    end
+  end
+
   context 'running a migration with #find_each' do
     let(:version) { 10 }
 


### PR DESCRIPTION
Rails 6 introduced [upsert_all](https://apidock.com/rails/v6.0.0/ActiveRecord/Persistence/ClassMethods/upsert_all) which delegates to `InsertAll` which ultimately calls `exec_query`. The MySQL upsert response is `nil` unlike postgres, so this PR accommodates for that response.

To reproduce:
- Run a migration that has any `upsert_all` call in it, it will error with `undefined method fields’ for nil:NilClass`