### PR TITLE
Allow database connection via socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Support for connection to MySQL server over socket
 
 ## [6.4.0] - 2020-06-23
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -2,3 +2,4 @@ username: <%= ENV['PERCONA_DB_USER'] || 'root' %>
 password: <%= ENV['PERCONA_DB_PASSWORD'] || '' %> 
 database: <%= ENV['PERCONA_DB_NAME'] || 'departure_test' %> 
 hostname: <%= ENV['PERCONA_DB_HOST'] || 'localhost' %>
+socket: <%= ENV['PERCONA_SOCKET'] || '' %>

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -2,4 +2,4 @@ username: <%= ENV['PERCONA_DB_USER'] || 'root' %>
 password: <%= ENV['PERCONA_DB_PASSWORD'] || '' %> 
 database: <%= ENV['PERCONA_DB_NAME'] || 'departure_test' %> 
 hostname: <%= ENV['PERCONA_DB_HOST'] || 'localhost' %>
-socket: <%= ENV['PERCONA_SOCKET'] || '' %>
+socket: <%= ENV['PERCONA_DB_SOCKET'] || '' %>

--- a/lib/departure/connection_details.rb
+++ b/lib/departure/connection_details.rb
@@ -96,12 +96,12 @@ module Departure
       ENV.fetch('PERCONA_DB_PASSWORD', connection_data[:password])
     end
 
-    # Returns the database socket path. If PERCONA_SOCKET is passed its value
+    # Returns the database socket path. If PERCONA_DB_SOCKET is passed its value
     # will be used instead
     #
     # @return [String]
     def socket
-      ENV.fetch('PERCONA_SOCKET', connection_data[:socket])
+      ENV.fetch('PERCONA_DB_SOCKET', connection_data[:socket])
     end
 
     # Returns the database's port.

--- a/lib/departure/connection_details.rb
+++ b/lib/departure/connection_details.rb
@@ -15,7 +15,7 @@ module Departure
     #
     # @return [String]
     def to_s
-      @to_s ||= "#{host_argument} -P #{port} -u #{user} #{password_argument}"
+      @to_s ||= "#{base_connection} -u #{user} #{password_argument}"
     end
 
     # TODO: Doesn't the abstract adapter already handle this somehow?
@@ -40,6 +40,19 @@ module Departure
       end
     end
 
+    private
+
+    attr_reader :connection_data
+
+    # Returns conditionaly socket or host configuration
+    #
+    # @return [String]
+    def base_connection
+      return "#{socket_argumet}" if socket.present?
+
+      "#{host_argument} -P #{port}"
+    end
+
     # Returns the host fragment of the details string, adds ssl options if needed
     #
     # @return [String]
@@ -51,9 +64,13 @@ module Departure
       "-h \"#{host_string}\""
     end
 
-    private
-
-    attr_reader :connection_data
+    # Returns the socket fragment
+    # FIXME: SSL connection
+    #
+    # @return [String]
+    def socket_argumet
+      "-S #{socket}"
+    end
 
     # Returns the database host name, defaulting to localhost. If PERCONA_DB_HOST
     # is passed its value will be used instead
@@ -77,6 +94,14 @@ module Departure
     # @return [String]
     def password
       ENV.fetch('PERCONA_DB_PASSWORD', connection_data[:password])
+    end
+
+    # Returns the database socket path. If PERCONA_SOCKET is passed its value
+    # will be used instead
+    #
+    # @return [String]
+    def socket
+      ENV.fetch('PERCONA_SOCKET', connection_data[:socket])
     end
 
     # Returns the database's port.

--- a/lib/departure/connection_details.rb
+++ b/lib/departure/connection_details.rb
@@ -5,7 +5,7 @@ module Departure
     DEFAULT_PORT = 3306
     # Constructor
     #
-    # @param [Hash] connection parametes as used in #establish_conneciton
+    # @param connection_data [Hash] connection parameters as used in #establish_conneciton
     def initialize(connection_data)
       @connection_data = connection_data
     end
@@ -44,11 +44,11 @@ module Departure
 
     attr_reader :connection_data
 
-    # Returns conditionaly socket or host configuration
+    # Returns conditionally host or socket configuration
     #
     # @return [String]
     def base_connection
-      return "#{socket_argumet}" if socket.present?
+      return socket_argument if socket.present?
 
       "#{host_argument} -P #{port}"
     end
@@ -64,11 +64,11 @@ module Departure
       "-h \"#{host_string}\""
     end
 
-    # Returns the socket fragment
+    # Returns the socket fragment of the details string
     # FIXME: SSL connection
     #
     # @return [String]
-    def socket_argumet
+    def socket_argument
       "-S #{socket}"
     end
 

--- a/spec/departure/connection_details_spec.rb
+++ b/spec/departure/connection_details_spec.rb
@@ -11,6 +11,8 @@ describe Departure::ConnectionDetails do
 
   describe '#to_s' do
     subject { connection_details.to_s }
+
+    let(:env_var) { {} }
     let(:connection_data) do
       {
         host: 'foo.com',
@@ -20,16 +22,16 @@ describe Departure::ConnectionDetails do
     end
 
     context 'when the port is not specified' do
-      let(:env_var) { {} }
       let(:connection_data) { { user: 'root', database: 'dummy_test' } }
+
       it { is_expected.to include("-P #{Departure::ConnectionDetails::DEFAULT_PORT}") }
     end
 
     context 'when the port is specified in the connection data' do
-      let(:env_var) { {} }
       let(:connection_data) { { user: 'root', database: 'dummy_test', port: 213 } }
 
       it { is_expected.to include('-P 213') }
+      it { is_expected.to_not include('-S ') }
     end
 
     context 'when the host is not specified' do
@@ -37,6 +39,23 @@ describe Departure::ConnectionDetails do
       let(:connection_data) { { user: 'root', database: 'dummy_test' } }
 
       it { is_expected.to include('-h "localhost"') }
+      it { is_expected.to_not include('-S ') }
+    end
+
+    context 'when the socket is specified in the connection data' do
+      let(:connection_data) { { socket: '/tmp/database.sock' } }
+
+      it { is_expected.to include('-S /tmp/database.sock') }
+      it { is_expected.to_not include('-h ') }
+      it { is_expected.to_not include('-P ') }
+    end
+
+    context 'when the socket and host is specified in the connection data' do
+      let(:connection_data) { { socket: '/tmp/database.sock', host: '127.0.0.1' } }
+
+      it { is_expected.to include('-S /tmp/database.sock') }
+      it { is_expected.to_not include('-h ') }
+      it { is_expected.to_not include('-P ') }
     end
 
     context 'when the host is specified' do
@@ -52,34 +71,56 @@ describe Departure::ConnectionDetails do
         let(:connection_data) do
           { host: 'foo.com:3306', user: 'root', database: 'dummy_test', sslca: '~/test.pem' }
         end
+
         it { is_expected.to include('-h "foo.com:3306;mysql_ssl=1;mysql_ssl_client_ca=~/test.pem"') }
       end
     end
 
     context 'when specifying PERCONA_DB_HOST' do
       let(:env_var) { { PERCONA_DB_HOST: 'foo.com:3306' } }
+
       it { is_expected.to include('h "foo.com:3306"') }
     end
 
     context 'when specifying PERCONA_DB_USER' do
       let(:env_var) { { PERCONA_DB_USER: 'percona' } }
+
       it { is_expected.to include('-u percona') }
     end
 
     context 'when specifying PERCONA_DB_PASSWORD' do
       let(:env_var) { { PERCONA_DB_PASSWORD: 'password' } }
+
       it { is_expected.to include('--password password') }
+    end
+
+    context 'when specifying PERCONA_SOCKET' do
+      let(:env_var) { { PERCONA_SOCKET: '/tmp/database.sock' } }
+
+      it { is_expected.to include('-S /tmp/database.sock') }
+      it { is_expected.to_not include('-h ') }
+      it { is_expected.to_not include('-P ') }
+    end
+
+    context 'when specifying PERCONA_SOCKET and PERCONA_HOST' do
+      let(:env_var) { { PERCONA_SOCKET: '/tmp/database.sock', PERCONA_HOST: '127.0.0.1' } }
+
+      it { is_expected.to include('-S /tmp/database.sock') }
+      it { is_expected.to_not include('-h ') }
+      it { is_expected.to_not include('-P ') }
     end
 
     context 'when the password contains bash incompatible characters' do
       let(:env_var) { { PERCONA_DB_PASSWORD: nil } }
       let(:connection_data) { { password: '!#/PASSWORD!!!' } }
+
       it { is_expected.to include('--password \!\#/PASSWORD\!\!\!') }
     end
   end
 
   describe '#database' do
     subject { connection_details.database }
+
     let(:connection_data) do
       {
         host: 'localhost',
@@ -90,6 +131,7 @@ describe Departure::ConnectionDetails do
 
     context 'when specifying PERCONA_DB_NAME' do
       let(:env_var) { { PERCONA_DB_NAME: 'dummy_database' } }
+
       it { is_expected.to eq('dummy_database') }
     end
   end

--- a/spec/departure/connection_details_spec.rb
+++ b/spec/departure/connection_details_spec.rb
@@ -94,16 +94,16 @@ describe Departure::ConnectionDetails do
       it { is_expected.to include('--password password') }
     end
 
-    context 'when specifying PERCONA_SOCKET' do
-      let(:env_var) { { PERCONA_SOCKET: '/tmp/database.sock' } }
+    context 'when specifying PERCONA_DB_SOCKET' do
+      let(:env_var) { { PERCONA_DB_SOCKET: '/tmp/database.sock' } }
 
       it { is_expected.to include('-S /tmp/database.sock') }
       it { is_expected.to_not include('-h ') }
       it { is_expected.to_not include('-P ') }
     end
 
-    context 'when specifying PERCONA_SOCKET and PERCONA_HOST' do
-      let(:env_var) { { PERCONA_SOCKET: '/tmp/database.sock', PERCONA_HOST: '127.0.0.1' } }
+    context 'when specifying PERCONA_DB_SOCKET and PERCONA_HOST' do
+      let(:env_var) { { PERCONA_DB_SOCKET: '/tmp/database.sock', PERCONA_HOST: '127.0.0.1' } }
 
       it { is_expected.to include('-S /tmp/database.sock') }
       it { is_expected.to_not include('-h ') }


### PR DESCRIPTION
This PR adds `PERCONA_DB_SOCKET` environment variable support and configuration property `socket` that has higher priority than `host` and `port` configuration.

Tested on staging environments with proxysql socket connection.

Created by @Levii01