### PR TITLE
Allow custom additions to general DSN via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 - Support for connection to MySQL server over socket
+- Support appending items to the general DSN. Used to apply workaround for [PT-2126](https://jira.percona.com/browse/PT-2126)
 
 ## [6.4.0] - 2020-06-23
 

--- a/lib/departure/dsn.rb
+++ b/lib/departure/dsn.rb
@@ -9,17 +9,17 @@ module Departure
     def initialize(database, table_name)
       @database = database
       @table_name = table_name
-      @added_dsn_items = ENV.fetch('PERCONA_ADDED_DSN_ITEMS', nil)
+      @suffix = ENV.fetch('PERCONA_DSN_SUFFIX', nil)
     end
 
     # Returns the pt-online-schema-change DSN string. See
     # https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html#dsn-options
     def to_s
-      "D=#{database},t=#{table_name}#{added_dsn_items.nil? ? nil : ',' + added_dsn_items}"
+      "D=#{database},t=#{table_name}#{suffix.nil? ? nil : ',' + suffix}"
     end
 
     private
 
-    attr_reader :table_name, :database, :added_dsn_items
+    attr_reader :table_name, :database, :suffix
   end
 end

--- a/lib/departure/dsn.rb
+++ b/lib/departure/dsn.rb
@@ -9,16 +9,17 @@ module Departure
     def initialize(database, table_name)
       @database = database
       @table_name = table_name
+      @added_dsn_items = ENV.fetch('PERCONA_ADDED_DSN_ITEMS', nil)
     end
 
     # Returns the pt-online-schema-change DSN string. See
     # https://www.percona.com/doc/percona-toolkit/2.0/pt-online-schema-change.html#dsn-options
     def to_s
-      "D=#{database},t=#{table_name}"
+      "D=#{database},t=#{table_name}#{added_dsn_items.nil? ? nil : ',' + added_dsn_items}"
     end
 
     private
 
-    attr_reader :table_name, :database
+    attr_reader :table_name, :database, :added_dsn_items
   end
 end

--- a/spec/departure/dsn_spec.rb
+++ b/spec/departure/dsn_spec.rb
@@ -4,8 +4,26 @@ describe Departure::DSN do
   let(:database) { 'development' }
   let(:table_name) { 'comments' }
 
+  around do |example|
+    ClimateControl.modify(env_var) do
+      example.run
+    end
+  end
+
   describe '#to_s' do
     subject { described_class.new(database, table_name).to_s }
-    it { is_expected.to eq('D=development,t=comments') }
+    let(:env_var) { {} }
+
+    context 'when a DSN suffix is not specified' do
+      it { is_expected.to eq('D=development,t=comments') }
+    end
+
+    context 'when a DSN suffix is specified' do
+      let(:env_var) { { PERCONA_DSN_SUFFIX: 'P=3306' } }
+
+      it 'tests for environment modification' do
+        is_expected.to eq('D=development,t=comments,P=3306')
+      end
+    end
   end
 end


### PR DESCRIPTION
As noted in [issue 86](https://github.com/departurerb/departure/issues/86), there is a bug in `pt-online-schema-change` where the `-P` option does not populate the port information for the general DSN which results in an "Use of uninitialized value" error.

This PR adds the ability to use "PERCONA_ADDED_DSN_ITEMS" environment variable to append items to the generated DSNs and, thereby, work around the existing bug with `pt-online-schema-change`.