### PR TITLE
Fix problem remove_index_for_alter for Rails 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
+## [Unreleased]
+
+- Fix support for Rails 6.0 and ForAlter `remove_index` .
+
 ## [6.5.0] - 2023-01-24
 
 - Support mysql gem version 0.5.5

--- a/lib/active_record/connection_adapters/for_alter.rb
+++ b/lib/active_record/connection_adapters/for_alter.rb
@@ -65,8 +65,14 @@ module ForAlterStatements
     end
   end
 
-  def remove_index_for_alter(table_name, column_name, options = {})
-    index_name = index_name_for_remove(table_name, column_name, options)
+  def remove_index_for_alter(table_name, column_name = nil, **options)
+    index_name =
+      if ActiveRecord::VERSION::STRING >= '6.1'
+        index_name_for_remove(table_name, column_name, options)
+      else
+        options = [column_name, options] if column_name
+        index_name_for_remove(table_name, options)
+      end
     "DROP INDEX #{quote_column_name(index_name)}"
   end
 

--- a/spec/fixtures/migrate/0028_change_table.rb
+++ b/spec/fixtures/migrate/0028_change_table.rb
@@ -1,7 +1,7 @@
 class ChangeTable < ActiveRecord::Migration[5.1]
   def change
     change_table :comments do |t|
-      t.column :renamable_field, :integer
+      t.column :renamable_field, :integer, index: true
     end
 
     change_table :comments do |t|
@@ -15,6 +15,7 @@ class ChangeTable < ActiveRecord::Migration[5.1]
 
     change_table :comments do |t|
       t.change(:hello, :integer)
+      t.remove_index(column: :renamed_id_field)
     end
   end
 end

--- a/spec/fixtures/migrate/0028_change_table.rb
+++ b/spec/fixtures/migrate/0028_change_table.rb
@@ -1,7 +1,8 @@
 class ChangeTable < ActiveRecord::Migration[5.1]
   def change
     change_table :comments do |t|
-      t.column :renamable_field, :integer, index: true
+      t.column :renamable_field, :integer
+      t.index :renamable_field
     end
 
     change_table :comments do |t|


### PR DESCRIPTION
Hi, in #62 it resolve a problem with `remove_index`, but the same problem is present in the `ForAlterStatements` module in the method `remove_index_for_alter`.

I simply added a `remove_index` in the integration test and using `RAILS_VERSION=6.0` make it failed.