### PR TITLE
Relax Rails dependency version to allow v7.1

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -7,7 +7,7 @@ require 'departure/version'
 
 # This environment variable is set on CI to facilitate testing with multiple
 # versions of Rails.
-RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '!= 7.0.0', '< 7.1'])
+RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '!= 7.0.0', '< 7.2'])
 
 Gem::Specification.new do |spec|
   spec.name          = 'departure'


### PR DESCRIPTION
This updates the dependency version to allow for the [recently released Rails 7.1](https://github.com/rails/rails/releases/tag/v7.1.0).