### PR TITLE
Support Rails 7.1.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - 5.2.0
           - 6.0.0
           - 6.1.0
+          - 7.1.2
         include:
           - ruby: 2.4
             rails: 5.2.0
@@ -22,6 +23,13 @@ jobs:
             rails: 7.0.1
           - ruby: 3.0
             rails: 6.1.0
+          - ruby: 3.0
+            rails: 7.1.2
+        exclude:
+          - ruby: 2.5
+            rails: 7.1.2
+          - ruby: 2.6
+            rails: 7.1.2
     env:
       PERCONA_DB_USER: root
       PERCONA_DB_PASSWORD: root

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,9 @@ Style/CommandLiteral:
 Style/Documentation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false # We never ended up being forced to do this for Ruby 3.x
+
 Style/MultilineBlockChain:
   Exclude:
     - 'spec/integration_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 ---
+AllCops:
+  TargetRubyVersion: 2.4
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 ## [Unreleased]
 
 - Fix support for Rails 6.0 and ForAlter `remove_index` .
+- Support Rails 7.1.2
 
 ## [6.5.0] - 2023-01-24
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.4
+FROM ruby:3.0
 MAINTAINER muffinista@gmail.com
 
 # Install apt based dependencies required to run Rails as

--- a/departure.gemspec
+++ b/departure.gemspec
@@ -7,7 +7,7 @@ require 'departure/version'
 
 # This environment variable is set on CI to facilitate testing with multiple
 # versions of Rails.
-RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '!= 7.0.0', '< 7.1'])
+RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '!= 7.0.0', '<= 7.1.2'])
 
 Gem::Specification.new do |spec|
   spec.name          = 'departure'

--- a/departure.gemspec
+++ b/departure.gemspec
@@ -7,7 +7,7 @@ require 'departure/version'
 
 # This environment variable is set on CI to facilitate testing with multiple
 # versions of Rails.
-RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '!= 7.0.0', '<= 7.1.2'])
+RAILS_DEPENDENCY_VERSION = ENV.fetch('RAILS_VERSION', ['>= 5.2.0', '!= 7.0.0', '< 7.2.0'])
 
 Gem::Specification.new do |spec|
   spec.name          = 'departure'

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -200,6 +200,10 @@ module ActiveRecord
 
       attr_reader :mysql_adapter
 
+      def self.less_than_active_record_7_1?
+        ActiveRecord.version < Gem::Version.create("7.1.0")
+      end
+
       def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
         log(sql, name, async: async) do
           with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
@@ -210,7 +214,7 @@ module ActiveRecord
             result
           end
         end
-      end
+      end unless less_than_active_record_7_1?
 
       def reconnect; end
     end

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -92,7 +92,7 @@ module ActiveRecord
       end
       alias exec_update exec_delete
 
-      def exec_insert(sql, name, binds, pk = nil, sequence_name = nil, returning: nil) # rubocop:disable Lint/UnusedMethodArgument, Metrics/LineLength
+      def exec_insert(sql, name, binds, pk = nil, sequence_name = nil, returning: nil) # rubocop:disable Lint/UnusedMethodArgument, Metrics/LineLength, Metrics/ParameterLists
         execute(to_sql(sql, binds), name)
       end
 
@@ -101,7 +101,7 @@ module ActiveRecord
         fields = result.fields if defined?(result.fields)
         ActiveRecord::Result.new(fields, result.to_a)
       end
-      alias :exec_query :internal_exec_query
+      alias exec_query internal_exec_query
 
       # Executes a SELECT query and returns an array of rows. Each row is an
       # array of field values.
@@ -212,8 +212,7 @@ module ActiveRecord
         end
       end
 
-      def reconnect
-      end
+      def reconnect; end
     end
   end
 end

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -200,21 +200,19 @@ module ActiveRecord
 
       attr_reader :mysql_adapter
 
-      def self.less_than_active_record_7_1?
-        ActiveRecord.version < Gem::Version.create("7.1.0")
-      end
-
-      def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
-        log(sql, name, async: async) do
-          with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-            sync_timezone_changes(conn)
-            result = conn.query(sql)
-            verified!
-            handle_warnings(sql)
-            result
+      if ActiveRecord.version >= Gem::Version.create('7.1.0')
+        def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
+          log(sql, name, async: async) do
+            with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
+              sync_timezone_changes(conn)
+              result = conn.query(sql)
+              verified!
+              handle_warnings(sql)
+              result
+            end
           end
         end
-      end unless less_than_active_record_7_1?
+      end
 
       def reconnect; end
     end

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -43,6 +43,8 @@ module ActiveRecord
 
   module ConnectionAdapters
     class DepartureAdapter < AbstractMysqlAdapter
+      TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) }
+
       class Column < ActiveRecord::ConnectionAdapters::MySQL::Column
         def adapter
           DepartureAdapter

--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -43,7 +43,7 @@ module ActiveRecord
 
   module ConnectionAdapters
     class DepartureAdapter < AbstractMysqlAdapter
-      TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) }
+      TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) } if defined?(initialize_type_map)
 
       class Column < ActiveRecord::ConnectionAdapters::MySQL::Column
         def adapter

--- a/lib/lhm/column_with_sql.rb
+++ b/lib/lhm/column_with_sql.rb
@@ -87,10 +87,10 @@ module Lhm
     #
     # @return [Boolean]
     def null_value
-      match = /((\w*) NULL)/i.match(definition)
+      match = /((NOT)? NULL)/i.match(definition)
       return true unless match
 
-      match[2].downcase == 'not' ? false : true
+      match[2]&.downcase == 'not' ? false : true
     end
   end
 end

--- a/lib/lhm/column_with_sql.rb
+++ b/lib/lhm/column_with_sql.rb
@@ -72,7 +72,7 @@ module Lhm
     #
     # @return [String, NilClass]
     def default_value
-      match = if definition =~ /timestamp|datetime/i
+      match = if definition.match?(/timestamp|datetime/i)
                 /default '?(.+[^'])'?/i.match(definition)
               else
                 /default '?(\w+)'?/i.match(definition)

--- a/spec/active_record/connection_adapters/percona_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/percona_adapter_spec.rb
@@ -181,12 +181,13 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
 
   describe '#exec_delete' do
     let(:sql) { 'DELETE FROM comments WHERE id = 1' }
+    let(:affected_rows) { 1 }
     let(:name) { nil }
     let(:binds) { nil }
 
     before do
-      allow(runner).to receive(:query).with(sql)
-      allow(runner).to receive(:affected_rows).and_return(1)
+      allow(runner).to receive(:query).with(anything)
+      allow(mysql_client).to receive(:affected_rows).and_return(affected_rows)
     end
 
     it 'executes the sql' do
@@ -195,7 +196,7 @@ describe ActiveRecord::ConnectionAdapters::DepartureAdapter do
     end
 
     it 'returns the number of affected rows' do
-      expect(adapter.exec_delete(sql, name, binds)).to eq(1)
+      expect(adapter.exec_delete(sql, name, binds)).to eq(affected_rows)
     end
   end
 

--- a/spec/integration/change_table_spec.rb
+++ b/spec/integration/change_table_spec.rb
@@ -3,11 +3,10 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_fixtures) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration).migrations.select do |m|
-      m.version == version
-    end
+  let(:migration_context) do
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
   end
+
   let(:direction) { :up }
 
   context 'change_table' do
@@ -19,7 +18,7 @@ describe Departure, integration: true do
 
     context 'creating column' do
       before(:each) do
-        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, version).migrate
+        migration_context.run(direction, version)
       end
 
       it 'adds the column in the DB table' do
@@ -38,7 +37,7 @@ describe Departure, integration: true do
       end
 
       it 'marks the migration as up' do
-        expect(ActiveRecord::Migrator.current_version).to eq(version)
+        expect(migration_context.current_version).to eq(version)
       end
 
       it 'changes column' do

--- a/spec/integration/data_migrations_spec.rb
+++ b/spec/integration/data_migrations_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_fixtures) { [MIGRATION_FIXTURES] }
+  let(:migration_context) do
+    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
+  end
+
   let(:direction) { :up }
 
   before do
@@ -25,21 +28,15 @@ describe Departure, integration: true do
     let(:version) { 9 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
       expect(Comment.pluck(:read)).to match_array([true, true])
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
-      expect(ActiveRecord::Migrator.current_version).to eq(version)
+      expect(migration_context.current_version).to eq(version)
     end
   end
 
@@ -47,10 +44,7 @@ describe Departure, integration: true do
     let(:version) { 30 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
       expect(Comment.pluck(:author, :read)).to match_array([
         [nil, false],
@@ -61,12 +55,9 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
-      expect(ActiveRecord::Migrator.current_version).to eq(version)
+      expect(migration_context.current_version).to eq(version)
     end
   end
 
@@ -74,21 +65,15 @@ describe Departure, integration: true do
     let(:version) { 10 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
       expect(Comment.pluck(:read)).to match_array([true, true])
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
-      expect(ActiveRecord::Migrator.current_version).to eq(version)
+      expect(migration_context.current_version).to eq(version)
     end
   end
 
@@ -96,21 +81,15 @@ describe Departure, integration: true do
     let(:version) { 11 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
       expect(Comment.pluck(:read)).to match_array([true, true])
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
-      expect(ActiveRecord::Migrator.current_version).to eq(version)
+      expect(migration_context.current_version).to eq(version)
     end
   end
 
@@ -118,21 +97,15 @@ describe Departure, integration: true do
     let(:version) { 12 }
 
     it 'updates all the required data' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
       expect(Comment.pluck(:read)).to match_array([true, true])
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_fixtures, ActiveRecord::SchemaMigration).run(
-        direction,
-        version
-      )
+      migration_context.run(direction, version)
 
-      expect(ActiveRecord::Migrator.current_version).to eq(version)
+      expect(migration_context.current_version).to eq(version)
     end
   end
 end

--- a/spec/integration/tables_spec.rb
+++ b/spec/integration/tables_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
+  let(:migration_context) do
+    ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration)
+  end
+
   let(:migration_paths) { [MIGRATION_FIXTURES] }
   let(:direction) { :up }
 
@@ -10,13 +14,13 @@ describe Departure, integration: true do
     let(:version) { 8 }
 
     it 'creates the table' do
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
+      migration_context.run(direction, version)
       expect(tables).to include('things')
     end
 
     it 'marks the migration as up' do
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
-      expect(ActiveRecord::Migrator.current_version).to eq(version)
+      migration_context.run(direction, version)
+      expect(migration_context.current_version).to eq(version)
     end
   end
 
@@ -25,13 +29,13 @@ describe Departure, integration: true do
     let(:direction) { :down }
 
     it 'drops the table' do
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
+      migration_context.run(direction, version)
       expect(tables).not_to include('things')
     end
 
     it 'updates the schema_migrations' do
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
-      expect(ActiveRecord::Migrator.current_version).to eq(0)
+      migration_context.run(direction, version)
+      expect(migration_context.current_version).to eq(0)
     end
   end
 
@@ -39,22 +43,22 @@ describe Departure, integration: true do
     let(:version) { 24 }
 
     before do
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, 1)
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, 2)
+      migration_context.run(direction, 1)
+      migration_context.run(direction, 2)
     end
 
     it 'changes the table name' do
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
+      migration_context.run(direction, version)
       expect(tables).to include('new_comments')
     end
 
     it 'does not keep the old name' do
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
+      migration_context.run(direction, version)
       expect(tables).not_to include('comments')
     end
 
     it 'changes the index names in the new table' do
-      ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
+      migration_context.run(direction, version)
       expect(:new_comments).to have_index('index_new_comments_on_some_id_field')
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -34,7 +34,7 @@ describe Departure, integration: true do
 
       it "doesn't send the output to stdout" do
         expect do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+          migration_context.run(direction, 1)
         end.to_not output.to_stdout
       end
     end
@@ -49,7 +49,7 @@ describe Departure, integration: true do
 
       it 'sends the output to stdout' do
         expect do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+          migration_context.run(direction, 1)
         end.to output.to_stdout
       end
     end
@@ -59,7 +59,7 @@ describe Departure, integration: true do
     let(:db_config) { Configuration.new }
 
     it 'reconnects to the database using PerconaAdapter' do
-      ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+      migration_context.run(direction, 1)
       expect(spec_config[:adapter]).to eq('percona')
     end
 
@@ -75,7 +75,7 @@ describe Departure, integration: true do
       end
 
       it 'uses the provided username' do
-        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+        migration_context.run(direction, 1)
         expect(spec_config[:username]).to eq('root')
       end
     end
@@ -91,7 +91,7 @@ describe Departure, integration: true do
       end
 
       it 'uses root' do
-        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+        migration_context.run(direction, 1)
         expect(spec_config[:username]).to eq('root')
       end
     end
@@ -101,14 +101,14 @@ describe Departure, integration: true do
       xit 'patches it to use regular Rails migration methods' do
         expect(Departure::Lhm::Fake::Adapter)
           .to receive(:new).and_return(true)
-        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+        migration_context.run(direction, 1)
       end
     end
 
     context 'when there is no LHM' do
       xit 'does not patch it' do
         expect(Departure::Lhm::Fake).not_to receive(:patching_lhm)
-        ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+        migration_context.run(direction, 1)
       end
     end
   end
@@ -174,7 +174,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--chunk-time=1' do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+          migration_context.run(direction, 1)
         end
       end
     end
@@ -187,7 +187,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--chunk-time=1 --max-lag=2' do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+          migration_context.run(direction, 1)
         end
       end
     end
@@ -200,7 +200,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--alter-foreign-keys-method=drop_swap' do
-          ActiveRecord::Migrator.new(direction, migration_fixtures, ActiveRecord::SchemaMigration, 1).migrate
+          migration_context.run(direction, 1)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,3 +79,7 @@ if ActiveRecord::VERSION::MAJOR < 6
   ActiveRecord::Migrator.send :prepend, Rails5Compatibility::Migrator
   ActiveRecord::MigrationContext.send :prepend, Rails5Compatibility::MigrationContext
 end
+
+if ActiveRecord::VERSION::STRING >= '7.1'
+  ActiveRecord::MigrationContext.send :prepend, Rails5Compatibility::MigrationContext
+end


### PR DESCRIPTION
Adds new methods to the Percona adapter required by a few changes in Rails 7.1:
* `raw_execute`:  https://github.com/rails/rails/pull/48061 reused the implementations from the MySQL2 adapter, but I can add any required customisations. 
* `internal_exec_query`: https://github.com/rails/rails/pull/48188 implementation from `exec_query`
* `reconnect`: I only added a stub because retries that way make less sense when offloading to PTOSC

On the tests front, I replaced `ActiveRecord::Migrator` with `ActiveRecord::MigrationContext` to solve method missing issues.

Gemspec/CI changes from https://github.com/departurerb/departure/pull/92