### PR TITLE
Avoid double definition of shared examples

### DIFF
--- a/spec/lhm/adapter/add_column_spec.rb
+++ b/spec/lhm/adapter/add_column_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'lhm/adapter/shared_example_column_definition_method_spec'
 
 describe Lhm::Adapter, '#add_column' do
   it_behaves_like 'column-definition method', :add_column

--- a/spec/lhm/adapter/change_column_spec.rb
+++ b/spec/lhm/adapter/change_column_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'lhm/adapter/shared_example_column_definition_method_spec'
 
 describe Lhm::Adapter, '#change_column' do
   it_behaves_like 'column-definition method', :change_column

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require 'lhm'
 require 'support/matchers/have_column'
 require 'support/matchers/have_index'
 require 'support/matchers/have_foreign_key_on'
+require 'support/shared_examples/column_definition_method'
 require 'support/table_methods'
 
 db_config = Configuration.new

--- a/spec/support/shared_examples/column_definition_method.rb
+++ b/spec/support/shared_examples/column_definition_method.rb
@@ -1,4 +1,3 @@
-# TODO: What about ENUM?
 shared_examples 'column-definition method' do |method_name|
   let(:migration) { double(:migration) }
   let(:table_name) { :comments }


### PR DESCRIPTION
Clears warnings when loading shared examples twice