### PR TITLE
Don't try to read error message from file if we are writing to stderr 

### DIFF
--- a/lib/departure/command.rb
+++ b/lib/departure/command.rb
@@ -83,7 +83,11 @@ module Departure
     #
     # @return [String]
     def error_message
-      File.read(error_log_path)
+      if redirect_stderr
+        File.read(error_log_path)
+      else
+        ''
+      end
     end
 
     # Logs when the execution started


### PR DESCRIPTION
This is a follow up from: https://github.com/departurerb/departure/pull/63

If redirect_stderr = false then we shouldn't attempt to read an error message from departure_error.log since 1) it won't exist 2) we've been writing stderr to stdout the whole time anyway.

Fixes this error that prints if a migration fails:
```
rails aborted!
StandardError: An error has occurred, all later migrations canceled:
Errno::ENOENT: No such file or directory @ rb_sysopen - /home/app/tmp/departure_error.log
```