### PR TITLE
Concurrent migration errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 - Create a `bin/rails` command that loads the database from the dummy application
 - Create a RailsAdapter that will handle creating connections inside of different versions of rails
 - Implement a Rails72DeparatureAdapater that handles the differences between Rails 7.2 and other rails versions
+- Implement a ActiveRecordMigratorWithAdvisoryLock for ActiveRecord versions 7.1 and 7.2 to prevent ConcurrentMigrationErrors
+- Implement a configuration option `disable_rails_advisory_lock_patch` to disable the ActiveRecordMigratorWithAdvisoryLock patch in our gem
 
 ## [6.7.0] - 2024-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 - Create a `bin/rails` command that loads the database from the dummy application
 - Create a RailsAdapter that will handle creating connections inside of different versions of rails
 - Implement a Rails72DeparatureAdapater that handles the differences between Rails 7.2 and other rails versions
-- Implement a ActiveRecordMigratorWithAdvisoryLock for ActiveRecord versions 7.1 and 7.2 to prevent ConcurrentMigrationErrors
+- Implement a ActiveRecordMigratorWithAdvisoryLock patch for ActiveRecord versions 7.1 and 7.2 to prevent ConcurrentMigrationErrors
 - Implement a configuration option `disable_rails_advisory_lock_patch` to disable the ActiveRecordMigratorWithAdvisoryLock patch in our gem
 
 ## [6.7.0] - 2024-02-20

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ end
 It's strongly recommended to name it after this gems name, such as
 `config/initializers/departure.rb`
 
+### Configuration Options
+
+All configuration options are configurable from the `Departure.configure` block example below
+
+|Option|Default|What it Controls|
+|---|---|---|
+|disable_rails_advisory_lock_patch|false|When truthy, disables a patch in at least rails 7.1 and 7.2 where rails throws ConcurrentMigrationErrors due to the inability to release the advisory lock in migrations|
+
 ### Disable on per-migration basis
 
 Departure gem is enabled by default.

--- a/lib/departure/configuration.rb
+++ b/lib/departure/configuration.rb
@@ -1,6 +1,6 @@
 module Departure
   class Configuration
-    attr_accessor :tmp_path, :global_percona_args, :enabled_by_default, :redirect_stderr
+    attr_accessor :tmp_path, :global_percona_args, :enabled_by_default, :redirect_stderr, :disable_rails_advisory_lock_patch
 
     def initialize
       @tmp_path = '.'.freeze

--- a/lib/departure/configuration.rb
+++ b/lib/departure/configuration.rb
@@ -1,6 +1,7 @@
 module Departure
   class Configuration
-    attr_accessor :tmp_path, :global_percona_args, :enabled_by_default, :redirect_stderr, :disable_rails_advisory_lock_patch
+    attr_accessor :tmp_path, :global_percona_args, :enabled_by_default, :redirect_stderr,
+                  :disable_rails_advisory_lock_patch
 
     def initialize
       @tmp_path = '.'.freeze

--- a/lib/departure/rails_adapter.rb
+++ b/lib/departure/rails_adapter.rb
@@ -78,14 +78,13 @@ module Departure
       class << self
         def register_integrations
           require 'active_record/connection_adapters/rails_7_2_departure_adapter'
-          require 'departure/rails_7_2/active_record_advisory_lock_patch'
+          require 'departure/rails_patches/active_record_migrator_with_advisory_lock_patch'
 
           ActiveSupport.on_load(:active_record) do
             ActiveRecord::Migration.class_eval do
               include Departure::Migration
             end
 
-            require 'departure/rails_patches/active_record_migrator_with_advisory_lock_patch'
             ActiveRecord::Migrator.prepend Departure::RailsPatches::ActiveRecordMigratorWithAdvisoryLockPatch
           end
 

--- a/lib/departure/rails_adapter.rb
+++ b/lib/departure/rails_adapter.rb
@@ -31,6 +31,12 @@ module Departure
             ActiveRecord::Migration.class_eval do
               include Departure::Migration
             end
+
+            if ActiveRecord::VERSION::MAJOR == 7 && ActiveRecord::VERSION::MINOR == 1
+              require 'departure/rails_patches/active_record_migrator_with_advisory_lock_patch'
+
+              ActiveRecord::Migrator.prepend Departure::RailsPatches::ActiveRecordMigratorWithAdvisoryLockPatch
+            end
           end
         end
 
@@ -72,11 +78,15 @@ module Departure
       class << self
         def register_integrations
           require 'active_record/connection_adapters/rails_7_2_departure_adapter'
+          require 'departure/rails_7_2/active_record_advisory_lock_patch'
 
           ActiveSupport.on_load(:active_record) do
             ActiveRecord::Migration.class_eval do
               include Departure::Migration
             end
+
+            require 'departure/rails_patches/active_record_migrator_with_advisory_lock_patch'
+            ActiveRecord::Migrator.prepend Departure::RailsPatches::ActiveRecordMigratorWithAdvisoryLockPatch
           end
 
           ActiveRecord::ConnectionAdapters.register 'percona',

--- a/lib/departure/rails_patches/active_record_migrator_with_advisory_lock_patch.rb
+++ b/lib/departure/rails_patches/active_record_migrator_with_advisory_lock_patch.rb
@@ -1,7 +1,8 @@
 module Departure
   module RailsPatches
     module ActiveRecordMigratorWithAdvisoryLockPatch
-      RELEASE_LOCK_FAILED_MESSAGE = "Failed to release advisory lock from ActiveRecordMigratorWithAdvisoryLockPatch"
+      RELEASE_LOCK_FAILED_MESSAGE = 'Failed to release advisory lock from ActiveRecordMigratorWithAdvisoryLockPatch'
+                                      .freeze
 
       def with_advisory_lock
         return super if Departure.configuration.disable_rails_advisory_lock_patch
@@ -11,13 +12,12 @@ module Departure
 
         got_lock = @__original_connection.get_advisory_lock(lock_id)
         raise ConcurrentMigrationError unless got_lock
+
         load_migrated # reload schema_migrations to be sure it wasn't changed by another process before we got the lock
         yield
       ensure
         if got_lock && !@__original_connection.release_advisory_lock(lock_id)
-          raise ConcurrentMigrationError.new(
-            RELEASE_LOCK_FAILED_MESSAGE
-          )
+          raise ConcurrentMigrationError, RELEASE_LOCK_FAILED_MESSAGE
         end
       end
     end

--- a/lib/departure/rails_patches/active_record_migrator_with_advisory_lock_patch.rb
+++ b/lib/departure/rails_patches/active_record_migrator_with_advisory_lock_patch.rb
@@ -4,6 +4,8 @@ module Departure
       RELEASE_LOCK_FAILED_MESSAGE = "Failed to release advisory lock from ActiveRecordMigratorWithAdvisoryLockPatch"
 
       def with_advisory_lock
+        return super if Departure.configuration.disable_rails_advisory_lock_patch
+
         lock_id = generate_migrator_advisory_lock_id
         @__original_connection = connection
 

--- a/lib/departure/rails_patches/active_record_migrator_with_advisory_lock_patch.rb
+++ b/lib/departure/rails_patches/active_record_migrator_with_advisory_lock_patch.rb
@@ -1,0 +1,23 @@
+module Departure
+  module RailsPatches
+    module ActiveRecordMigratorWithAdvisoryLockPatch
+      RELEASE_LOCK_FAILED_MESSAGE = "Failed to release advisory lock from ActiveRecordMigratorWithAdvisoryLockPatch"
+
+      def with_advisory_lock
+        lock_id = generate_migrator_advisory_lock_id
+        @__original_connection = connection
+
+        got_lock = @__original_connection.get_advisory_lock(lock_id)
+        raise ConcurrentMigrationError unless got_lock
+        load_migrated # reload schema_migrations to be sure it wasn't changed by another process before we got the lock
+        yield
+      ensure
+        if got_lock && !@__original_connection.release_advisory_lock(lock_id)
+          raise ConcurrentMigrationError.new(
+            RELEASE_LOCK_FAILED_MESSAGE
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/change_table_spec.rb
+++ b/spec/integration/change_table_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_context) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
-  end
-
   let(:direction) { :up }
 
   context 'change_table' do
@@ -18,7 +14,7 @@ describe Departure, integration: true do
 
     context 'creating column' do
       before(:each) do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
       end
 
       it 'adds the column in the DB table' do
@@ -37,7 +33,7 @@ describe Departure, integration: true do
       end
 
       it 'marks the migration as up' do
-        expect(migration_context.current_version).to eq(version)
+        expect(current_migration_version).to eq(version)
       end
 
       it 'changes column' do

--- a/spec/integration/columns_spec.rb
+++ b/spec/integration/columns_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_context) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
-  end
-
   let(:direction) { :up }
 
   context 'managing columns' do
@@ -16,35 +12,33 @@ describe Departure, integration: true do
       let(:direction) { :up }
 
       it 'adds the column in the DB table' do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
 
         expect(:comments).to have_column('some_id_field')
       end
 
       it 'marks the migration as up' do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
 
-        expect(migration_context.current_version).to eq(version)
+        expect(current_migration_version).to eq(version)
       end
     end
 
     context 'dropping column' do
       let(:direction) { :down }
 
-      before do
-        migration_context.up(version)
-      end
+      before { run_a_migration(:up, version) }
 
       it 'drops the column from the DB table' do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
 
         expect(:comments).not_to have_column('some_id_field')
       end
 
       it 'marks the migration as down' do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
 
-        expect(migration_context.current_version).to eq(version - 1)
+        expect(current_migration_version).to eq(version - 1)
       end
     end
 
@@ -61,12 +55,12 @@ describe Departure, integration: true do
       end
 
       it 'changes the column name' do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
         expect(:comments).to have_column('new_id_field')
       end
 
       it 'does not keep the old column' do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
         expect(:comments).not_to have_column('some_id_field')
       end
     end
@@ -78,21 +72,19 @@ describe Departure, integration: true do
       columns(:comments).find { |column| column.name == 'some_id_field' }
     end
 
-    before do
-      migration_context.up(1)
-    end
+    before { run_a_migration(:up, 1) }
 
     context 'when null is true' do
       let(:version) { 14 }
 
       it 'sets the column to allow nulls' do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
         expect(column.null).to be_truthy
       end
 
       it 'marks the migration as up' do
-        migration_context.run(direction, version)
-        expect(migration_context.current_version).to eq(version)
+        run_a_migration(direction, version)
+        expect(current_migration_version).to eq(version)
       end
     end
 
@@ -100,13 +92,13 @@ describe Departure, integration: true do
       let(:version) { 15 }
 
       it 'sets the column not to allow nulls' do
-        migration_context.run(direction, version)
+        run_a_migration(direction, version)
         expect(column.null).to be_falsey
       end
 
       it 'marks the migration as up' do
-        migration_context.run(direction, version)
-        expect(migration_context.current_version).to eq(version)
+        run_a_migration(direction, version)
+        expect(current_migration_version).to eq(version)
       end
     end
   end
@@ -115,12 +107,12 @@ describe Departure, integration: true do
     let(:version) { 22 }
 
     it 'adds a created_at column' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(:comments).to have_column('created_at')
     end
 
     it 'adds a updated_at column' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(:comments).to have_column('updated_at')
     end
   end
@@ -137,12 +129,12 @@ describe Departure, integration: true do
     end
 
     it 'removes the created_at column' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(:comments).not_to have_column('created_at')
     end
 
     it 'removes the updated_at column' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(:comments).not_to have_column('updated_at')
     end
   end

--- a/spec/integration/data_migrations_spec.rb
+++ b/spec/integration/data_migrations_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_context) do
-    ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
-  end
-
   let(:direction) { :up }
 
   before do
@@ -28,15 +24,15 @@ describe Departure, integration: true do
     let(:version) { 9 }
 
     it 'updates all the required data' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
       expect(Comment.pluck(:read)).to match_array([true, true])
     end
 
     it 'marks the migration as up' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
-      expect(migration_context.current_version).to eq(version)
+      expect(current_migration_version).to eq(version)
     end
   end
 
@@ -44,7 +40,7 @@ describe Departure, integration: true do
     let(:version) { 30 }
 
     it 'updates all the required data' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
       expect(Comment.pluck(:author, :read)).to match_array([
         [nil, false],
@@ -55,9 +51,9 @@ describe Departure, integration: true do
     end
 
     it 'marks the migration as up' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
-      expect(migration_context.current_version).to eq(version)
+      expect(current_migration_version).to eq(version)
     end
   end
 
@@ -65,15 +61,15 @@ describe Departure, integration: true do
     let(:version) { 10 }
 
     it 'updates all the required data' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
       expect(Comment.pluck(:read)).to match_array([true, true])
     end
 
     it 'marks the migration as up' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
-      expect(migration_context.current_version).to eq(version)
+      expect(current_migration_version).to eq(version)
     end
   end
 
@@ -81,15 +77,15 @@ describe Departure, integration: true do
     let(:version) { 11 }
 
     it 'updates all the required data' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
       expect(Comment.pluck(:read)).to match_array([true, true])
     end
 
     it 'marks the migration as up' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
-      expect(migration_context.current_version).to eq(version)
+      expect(current_migration_version).to eq(version)
     end
   end
 
@@ -97,15 +93,15 @@ describe Departure, integration: true do
     let(:version) { 12 }
 
     it 'updates all the required data' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
       expect(Comment.pluck(:read)).to match_array([true, true])
     end
 
     it 'marks the migration as up' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
 
-      expect(migration_context.current_version).to eq(version)
+      expect(current_migration_version).to eq(version)
     end
   end
 end

--- a/spec/integration/rails_adapter_spec.rb
+++ b/spec/integration/rails_adapter_spec.rb
@@ -2,30 +2,23 @@ require 'spec_helper'
 
 RSpec.describe Departure::RailsAdapter, integration: true do
   describe "advisory_lock patch" do
-    before(:each) do
-      # We have to force a reconnection in order to get a migration error when we switch adapters
-      establish_mysql_connection
-    end
-
     def run_a_migration
       migration_context = ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
       migration_context.run(:up, 1)
     end
 
     it "runs migrations without throwing an ActiveRecord::ConcurrentMigration Error" do
-      establish_mysql_connection
-
       expect { run_a_migration }.not_to raise_error
     end
 
     it "throws an exception when we are in rails 7.1 and have the patch disabled", activerecord_compatibility: "> 7.1" do
-      Departure.configure do |config|
-        config.disable_rails_advisory_lock_patch = true
-      end
+      disable_departure_rails_advisory_lock_patch
 
       establish_mysql_connection
 
       expect { run_a_migration }.to raise_error(ActiveRecord::ConcurrentMigrationError)
+    ensure
+      enable_departure_rails_advisory_lock_patch
     end
   end
 end

--- a/spec/integration/rails_adapter_spec.rb
+++ b/spec/integration/rails_adapter_spec.rb
@@ -2,13 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Departure::RailsAdapter, integration: true do
   describe "advisory_lock patch" do
-    def run_a_migration
-      migration_context = ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
-      migration_context.run(:up, 1)
-    end
-
     it "runs migrations without throwing an ActiveRecord::ConcurrentMigration Error" do
-      expect { run_a_migration }.not_to raise_error
+      expect { run_a_migration(:up, 1) }.not_to raise_error
     end
 
     it "throws an exception when we are in rails 7.1 and have the patch disabled", activerecord_compatibility: "> 7.1" do
@@ -16,7 +11,7 @@ RSpec.describe Departure::RailsAdapter, integration: true do
 
       establish_mysql_connection
 
-      expect { run_a_migration }.to raise_error(ActiveRecord::ConcurrentMigrationError)
+      expect { run_a_migration(:up, 1) }.to raise_error(ActiveRecord::ConcurrentMigrationError)
     ensure
       enable_departure_rails_advisory_lock_patch
     end

--- a/spec/integration/rails_adapter_spec.rb
+++ b/spec/integration/rails_adapter_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe Departure::RailsAdapter, integration: true do
+  describe "advisory_lock patch" do
+    before(:each) do
+      # We have to force a reconnection in order to get a migration error when we switch adapters
+      establish_mysql_connection
+    end
+
+    def run_a_migration
+      migration_context = ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
+      migration_context.run(:up, 1)
+    end
+
+    it "runs migrations without throwing an ActiveRecord::ConcurrentMigration Error" do
+      establish_mysql_connection
+
+      expect { run_a_migration }.not_to raise_error
+    end
+
+    it "throws an exception when we are in rails 7.1 and have the patch disabled", activerecord_compatibility: "> 7.1" do
+      Departure.configure do |config|
+        config.disable_rails_advisory_lock_patch = true
+      end
+
+      establish_mysql_connection
+
+      expect { run_a_migration }.to raise_error(ActiveRecord::ConcurrentMigrationError)
+    end
+  end
+end
+
+

--- a/spec/integration/rails_adapter_spec.rb
+++ b/spec/integration/rails_adapter_spec.rb
@@ -1,12 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe Departure::RailsAdapter, integration: true do
-  describe "advisory_lock patch" do
-    it "runs migrations without throwing an ActiveRecord::ConcurrentMigration Error" do
+  describe 'advisory_lock patch' do
+    it 'runs migrations without throwing an ActiveRecord::ConcurrentMigration Error' do
       expect { run_a_migration(:up, 1) }.not_to raise_error
     end
 
-    it "throws an exception when we are in rails 7.1 and have the patch disabled", activerecord_compatibility: "> 7.1" do
+    it 'throws an exception when we are in rails 7.1 and have the patch disabled',
+       activerecord_compatibility: '> 7.1' do
       disable_departure_rails_advisory_lock_patch
 
       establish_mysql_connection
@@ -17,5 +18,3 @@ RSpec.describe Departure::RailsAdapter, integration: true do
     end
   end
 end
-
-

--- a/spec/integration/tables_spec.rb
+++ b/spec/integration/tables_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_context) do
-    ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration)
-  end
-
   let(:migration_paths) { [MIGRATION_FIXTURES] }
   let(:direction) { :up }
 
@@ -14,13 +10,13 @@ describe Departure, integration: true do
     let(:version) { 8 }
 
     it 'creates the table' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(tables).to include('things')
     end
 
     it 'marks the migration as up' do
-      migration_context.run(direction, version)
-      expect(migration_context.current_version).to eq(version)
+      run_a_migration(direction, version)
+      expect(current_migration_version).to eq(version)
     end
   end
 
@@ -29,13 +25,13 @@ describe Departure, integration: true do
     let(:direction) { :down }
 
     it 'drops the table' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(tables).not_to include('things')
     end
 
     it 'updates the schema_migrations' do
-      migration_context.run(direction, version)
-      expect(migration_context.current_version).to eq(0)
+      run_a_migration(direction, version)
+      expect(current_migration_version).to eq(0)
     end
   end
 
@@ -43,22 +39,22 @@ describe Departure, integration: true do
     let(:version) { 24 }
 
     before do
-      migration_context.run(direction, 1)
-      migration_context.run(direction, 2)
+      run_a_migration(direction, 1)
+      run_a_migration(direction, 2)
     end
 
     it 'changes the table name' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(tables).to include('new_comments')
     end
 
     it 'does not keep the old name' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(tables).not_to include('comments')
     end
 
     it 'changes the index names in the new table' do
-      migration_context.run(direction, version)
+      run_a_migration(direction, version)
       expect(:new_comments).to have_index('index_new_comments_on_some_id_field')
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -134,7 +134,7 @@ describe Departure, integration: true do
 
       it 'raises and halts the execution' do
         expect do
-          run_a_migration(direction, version)
+          ActiveRecord::Migrator.run(direction, migration_fixtures, ActiveRecord::SchemaMigration, version)
         end.to raise_error do |exception|
           exception.cause == Departure::SignalError
         end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -5,10 +5,6 @@ require_relative './dummy/db/migrate/0022_add_timestamp_on_comments'
 describe Departure, integration: true do
   class Comment < ActiveRecord::Base; end
 
-  let(:migration_paths) { [MIGRATION_FIXTURES] }
-  let(:migration_context) { ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration) }
-  let(:migration_fixtures) { migration_context.migrations }
-
   let(:direction) { :up }
   let(:pool) { ActiveRecord::Base.connection_pool }
   let(:spec_config) do
@@ -34,7 +30,7 @@ describe Departure, integration: true do
 
       it "doesn't send the output to stdout" do
         expect do
-          migration_context.run(direction, 1)
+          run_a_migration(direction, 1)
         end.to_not output.to_stdout
       end
     end
@@ -49,7 +45,7 @@ describe Departure, integration: true do
 
       it 'sends the output to stdout' do
         expect do
-          migration_context.run(direction, 1)
+          run_a_migration(direction, 1)
         end.to output.to_stdout
       end
     end
@@ -59,7 +55,7 @@ describe Departure, integration: true do
     let(:db_config) { Configuration.new }
 
     it 'reconnects to the database using PerconaAdapter' do
-      migration_context.run(direction, 1)
+      run_a_migration(direction, 1)
       expect(spec_config[:adapter]).to eq('percona')
     end
 
@@ -75,7 +71,7 @@ describe Departure, integration: true do
       end
 
       it 'uses the provided username' do
-        migration_context.run(direction, 1)
+        run_a_migration(direction, 1)
         expect(spec_config[:username]).to eq('root')
       end
     end
@@ -91,7 +87,7 @@ describe Departure, integration: true do
       end
 
       it 'uses root' do
-        migration_context.run(direction, 1)
+        run_a_migration(direction, 1)
         expect(spec_config[:username]).to eq('root')
       end
     end
@@ -101,14 +97,14 @@ describe Departure, integration: true do
       xit 'patches it to use regular Rails migration methods' do
         expect(Departure::Lhm::Fake::Adapter)
           .to receive(:new).and_return(true)
-        migration_context.run(direction, 1)
+        run_a_migration(direction, 1)
       end
     end
 
     context 'when there is no LHM' do
       xit 'does not patch it' do
         expect(Departure::Lhm::Fake).not_to receive(:patching_lhm)
-        migration_context.run(direction, 1)
+        run_a_migration(direction, 1)
       end
     end
   end
@@ -121,7 +117,7 @@ describe Departure, integration: true do
 
       it 'raises and halts the execution' do
         expect do
-          ActiveRecord::Migrator.run(direction, migration_fixtures, ActiveRecord::SchemaMigration, version)
+          run_a_migration(direction, version)
         end.to raise_error do |exception|
           exception.cause == ActiveRecord::StatementInvalid
         end
@@ -138,7 +134,7 @@ describe Departure, integration: true do
 
       it 'raises and halts the execution' do
         expect do
-          ActiveRecord::Migrator.run(direction, migration_fixtures, ActiveRecord::SchemaMigration, version)
+          run_a_migration(direction, version)
         end.to raise_error do |exception|
           exception.cause == Departure::SignalError
         end
@@ -152,7 +148,7 @@ describe Departure, integration: true do
     it 'raises and halts the execution' do
       expect do
         ClimateControl.modify PATH: '' do
-          ActiveRecord::Migrator.run(direction, migration_fixtures, ActiveRecord::SchemaMigration, version)
+          run_a_migration(direction, version)
         end
       end.to raise_error do |exception|
         exception.cause == Departure::CommandNotFoundError
@@ -174,7 +170,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--chunk-time=1' do
-          migration_context.run(direction, 1)
+          run_a_migration(direction, 1)
         end
       end
     end
@@ -187,7 +183,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--chunk-time=1 --max-lag=2' do
-          migration_context.run(direction, 1)
+          run_a_migration(direction, 1)
         end
       end
     end
@@ -200,7 +196,7 @@ describe Departure, integration: true do
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--alter-foreign-keys-method=drop_swap' do
-          migration_context.run(direction, 1)
+          run_a_migration(direction, 1)
         end
       end
     end
@@ -210,7 +206,7 @@ describe Departure, integration: true do
     it 'uses Departure::OriginalConnectionAdapter' do
       expect(Departure::OriginalAdapterConnection).to receive(:establish_connection)
 
-      migration_context.run(direction, 29) # DisableDeparture
+      run_a_migration(direction, 29) # DisableDeparture
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -204,6 +204,7 @@ describe Departure, integration: true do
 
   context 'when there are migrations that do not use departure' do
     it 'uses Departure::OriginalConnectionAdapter' do
+      establish_percona_connection
       expect(Departure::OriginalAdapterConnection).to receive(:establish_connection)
 
       run_a_migration(direction, 29) # DisableDeparture

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,6 @@ db_config = Configuration.new
 fd = ENV['VERBOSE'] ? STDOUT : '/dev/null'
 ActiveRecord::Base.logger = Logger.new(fd)
 
-
 test_database = TestDatabase.new(db_config)
 
 Departure::RailsAdapter.for_current.register_integrations

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,6 @@ db_config = Configuration.new
 fd = ENV['VERBOSE'] ? STDOUT : '/dev/null'
 ActiveRecord::Base.logger = Logger.new(fd)
 
-MIGRATION_FIXTURES = File.expand_path('../dummy/db/migrate/', __FILE__)
 
 test_database = TestDatabase.new(db_config)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,18 @@ ActiveRecord::Base.establish_connection(
   database: db_config['database']
 )
 
+def establish_mysql_connection
+  db_config = Configuration.new
+
+  ActiveRecord::Base.establish_connection(
+    adapter: 'mysql2',
+    host: db_config['hostname'],
+    username: db_config['username'],
+    password: db_config['password'],
+    database: db_config['database']
+  )
+end
+
 MIGRATION_FIXTURES = File.expand_path('../dummy/db/migrate/', __FILE__)
 
 test_database = TestDatabase.new(db_config)

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -1,6 +1,8 @@
 MIGRATION_FIXTURES = File.expand_path('../dummy/db/migrate', __dir__)
 
 def establish_percona_connection
+  db_config = Configuration.new
+
   ActiveRecord::Base.establish_connection(
     adapter: 'percona',
     host: db_config['hostname'],

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -1,3 +1,5 @@
+MIGRATION_FIXTURES = File.expand_path('../../dummy/db/migrate/', __FILE__)
+
 def establish_percona_connection
   ActiveRecord::Base.establish_connection(
     adapter: 'percona',
@@ -32,7 +34,14 @@ def enable_departure_rails_advisory_lock_patch
   end
 end
 
+def migration_context
+  ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
+end
+
 def run_a_migration(direction, target_version)
-  migration_context = ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
   migration_context.run(direction, target_version)
+end
+
+def current_migration_version
+  migration_context.current_version
 end

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -31,3 +31,8 @@ def enable_departure_rails_advisory_lock_patch
     config.disable_rails_advisory_lock_patch = false
   end
 end
+
+def run_a_migration(direction, target_version)
+  migration_context = ActiveRecord::MigrationContext.new([MIGRATION_FIXTURES], ActiveRecord::SchemaMigration)
+  migration_context.run(direction, target_version)
+end

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -1,4 +1,4 @@
-MIGRATION_FIXTURES = File.expand_path('../../dummy/db/migrate/', __FILE__)
+MIGRATION_FIXTURES = File.expand_path('../dummy/db/migrate', __dir__)
 
 def establish_percona_connection
   ActiveRecord::Base.establish_connection(

--- a/spec/support/database_helpers.rb
+++ b/spec/support/database_helpers.rb
@@ -1,0 +1,33 @@
+def establish_percona_connection
+  ActiveRecord::Base.establish_connection(
+    adapter: 'percona',
+    host: db_config['hostname'],
+    username: db_config['username'],
+    password: db_config['password'],
+    database: db_config['database']
+  )
+end
+
+def establish_mysql_connection
+  db_config = Configuration.new
+
+  ActiveRecord::Base.establish_connection(
+    adapter: 'mysql2',
+    host: db_config['hostname'],
+    username: db_config['username'],
+    password: db_config['password'],
+    database: db_config['database']
+  )
+end
+
+def disable_departure_rails_advisory_lock_patch
+  Departure.configure do |config|
+    config.disable_rails_advisory_lock_patch = true
+  end
+end
+
+def enable_departure_rails_advisory_lock_patch
+  Departure.configure do |config|
+    config.disable_rails_advisory_lock_patch = false
+  end
+end


### PR DESCRIPTION
*INFO* This PR builds on top of the `green-rails7.2` branch, you can compare the two [in this link](https://github.com/Austio/departure/compare/green-7.2..concurrent-migration-errors)

Prior to this change with departure, rails 7.1 and rails 7.2 would raise an `ActiveRecord::ConcurrentMigrationError` when running migrations *even* though the migrations successfully ran.  This migration error would also prevent `schema.rb` from being updated properly to reflect the current db schema after migration are ran.

This PR updates our rails adapter in verions 7.1 and 7.2 to ensure we don't raise an `ActiveRecord::ConcurrentMigrationError` when running migrations through patching `ActiveRecord::Migrator` to ensure we get and set an advisory lock with the same thread (see background below for more details).  It also fixes an outstanding bug where `schema.rb` was not updating after migrations ran.

### Underlying Problem Description

`ActiveRecord::ConcurrentMigrationError` during migrations in rails 7.1 and 7.2 happened because of the way departure and advisory locks work
 - advisory locks in mysql are bound to a thread, so when an application sets an advisory lock with a connection it must release it with that same thread bound connection in the databse
 - when we declare our database adapter in database.yml as `mysql2` we establish a connection with that when connecting to the databse
 - when departure runs and we detect an alter table migration, we change the adapter to `percona`
 - this creates a new connection, which has a different thread (in the mysql database server due to the new connection) than the initial `mysql` connection

When running a migration, this is the code flow
 - ActiveRecord::Migration runs your migration `with_advisory_lock` in the context of the `mysql2` db connection
 - `with_advisory_lock` generates a lock id based on the database name
 - the connection gets an advisory lock with the unique id
 - we yield, which calls to departure, who sets a new `percona` db connection (a different thread bound connection from our mysql database server)
 - departure uses pt-online-schema-change
 - finally, we successfully run the migration and cleanup ensuring we releasing the advisory lock
 - **BOOM** - we raise an exception because the current `connection` is `departure` and not `mysql2` - mysql db will not allow us to release an advisory lock from a different thread that created the lock and `release_advisory_lock` returns 0, causing active record to throw a `ConcurrentMigrationError`

```
    def with_advisory_lock
        lock_id = generate_migrator_advisory_lock_id
   
        # The first connection is `mysql` which has a specific thread from the mysql server
        got_lock = connection.get_advisory_lock(lock_id) 
        raise ConcurrentMigrationError unless got_lock
        load_migrated # reload schema_migrations to be sure it wasn't changed by another process before we got the lock
        yield
      ensure
        # if we switched to the percona adapter, there is a new connection which has a different thread in mysql server
        if got_lock && !connection.release_advisory_lock(lock_id)
          puts "failed to release lock"
          raise ConcurrentMigrationError.new(
            ConcurrentMigrationError::RELEASE_LOCK_FAILED_MESSAGE
          )
        end
      end
```


Our solution is pretty simple, when we are in rails 7.1 or 7.2, we patch the `with_advisory_lock` method to save the initial connection to an ivar, we then get and release the advisory lock with that connection 


### Background

Advisory Locks are "application" locks that databases support to signal and put a mutex around exclusive actions, for Departure that relates to the migrations that we wrap in order to run `pt-online-schema-change` when we do alter table statements

ActiveRecord::Migrator uses the concept of getting and setting advisory locks related to the database name to ensure that if you are running migrations in production amongst N nodes, that only one of them will actually issue the database schema migrations.

Rails 7.1 introduced a change that removed the concept of an independent database adapter agnostic advisory lock in favor of using the adapters advisory lock [in this commit]( https://github.com/rails/rails/commit/07d8b99ebeddf110df8fba8e18985ca176d60046) kuddos to @douglas for finding the exact commit.  The Rails PR making this change [is Here](https://github.com/rails/rails/pull/46224)


