### PR TITLE
Remove Most non pt-online-schema-change logic from Departure

### DIFF
--- a/lib/active_record/connection_adapters/rails_8_1_departure_adapter.rb
+++ b/lib/active_record/connection_adapters/rails_8_1_departure_adapter.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         percona_logger = Departure::LoggerFactory.build(sanitizers: sanitizers, verbose: verbose)
         cli_generator = Departure::CliGenerator.new(connection_details)
 
-        mysql_adapter = ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(config.merge(adapter: 'mysql2'))
+        mysql_adapter = ::Mysql2::Client.new(config)
 
         Departure::DbClient.new(
           percona_logger,

--- a/lib/active_record/connection_adapters/rails_8_1_departure_adapter.rb
+++ b/lib/active_record/connection_adapters/rails_8_1_departure_adapter.rb
@@ -71,89 +71,13 @@ module ActiveRecord
 
       attr_reader :mysql_adapter
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/ParameterLists
+      # rubocop:disable Metrics/ParameterLists
       def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:, batch: false)
-        reset_multi_statement = if batch && !multi_statements_enabled?
-                                  raw_connection.set_server_option(::Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
-                                  true
-                                end
+        return raw_connection.send_to_pt_online_schema_change(sql) if raw_connection.alter_statement?(sql)
 
-        # Make sure we carry over any changes to ActiveRecord.default_timezone that have been
-        # made since we established the connection
-        raw_connection.query_options[:database_timezone] = default_timezone
-
-        result = nil
-        if binds.nil? || binds.empty?
-          result = raw_connection.query(sql)
-          # Ref: https://github.com/brianmario/mysql2/pull/1383
-          # As of mysql2 0.5.6 `#affected_rows` might raise Mysql2::Error if a prepared statement
-          # from that same connection was GCed while `#query` released the GVL.
-          # By avoiding to call `#affected_rows` when we have a result, we reduce the likeliness
-          # of hitting the bug.
-
-          # THIS IS THE CORE CHANGES 2 related to size - it will not be present on pt-online-schema-migrator calls
-          @affected_rows_before_warnings = result.try(:size) || raw_connection.affected_rows
-        elsif prepare
-          retry_count = 1
-          begin
-            stmt = @statements[sql] ||= raw_connection.prepare(sql)
-            result = stmt.execute(*type_casted_binds)
-            @affected_rows_before_warnings = stmt.affected_rows
-          rescue ::Mysql2::Error => e
-            @statements.delete(sql)
-            # Sometimes for an unknown reason, we get that error.
-            # It suggest somehow that the prepared statement was deallocated
-            # but the client doesn't know it.
-            # But we know that this error is safe to retry, so we do so after
-            # getting rid of the originally cached statement.
-            if e.error_number == Mysql2Adapter::ER_UNKNOWN_STMT_HANDLER && retry_count.positive?
-              retry_count -= 1
-              retry
-            end
-            raise
-          end
-        else
-          stmt = raw_connection.prepare(sql)
-
-          begin
-            result = stmt.execute(*type_casted_binds)
-            @affected_rows_before_warnings = stmt.affected_rows
-
-            # Ref: https://github.com/brianmario/mysql2/pull/1383
-            # by eagerly closing uncached prepared statements, we also reduce the chances of
-            # that bug happening. It can still happen if `#execute` is used as we have no callback
-            # to eagerly close the statement.
-            if result
-              result.instance_variable_set(:@_ar_stmt_to_close, stmt)
-            else
-              stmt.close
-            end
-          rescue ::Mysql2::Error
-            stmt.close
-            raise
-          end
-        end
-
-        notification_payload[:affected_rows] = @affected_rows_before_warnings
-
-        # THIS IS THE CORE CHANGES 2 related to size - it will not be present on pt-online-schema-migrator calls
-        notification_payload[:row_count] = result.try(:size) || 0
-
-        if result.is_a? Process::Status
-          notification_payload[:exit_code] = result.exitstatus
-          notification_payload[:exit_pid] = result.pid
-        end
-
-        raw_connection.abandon_results!
-
-        verified!
-        result
-      ensure
-        if reset_multi_statement && active?
-          raw_connection.set_server_option(::Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
-        end
+        super
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/ParameterLists
+      # rubocop:enable Metrics/ParameterLists
     end
   end
 end

--- a/lib/active_record/connection_adapters/rails_8_1_departure_adapter.rb
+++ b/lib/active_record/connection_adapters/rails_8_1_departure_adapter.rb
@@ -40,21 +40,9 @@ module ActiveRecord
       ADAPTER_NAME = 'Percona'.freeze
 
       def self.new_client(config)
-        connection_details = Departure::ConnectionDetails.new(config)
-        verbose = ActiveRecord::Migration.verbose
-        sanitizers = [
-          Departure::LogSanitizers::PasswordSanitizer.new(connection_details)
-        ]
-        percona_logger = Departure::LoggerFactory.build(sanitizers: sanitizers, verbose: verbose)
-        cli_generator = Departure::CliGenerator.new(connection_details)
+        original_client = super
 
-        mysql_adapter = ::Mysql2::Client.new(config)
-
-        Departure::DbClient.new(
-          percona_logger,
-          cli_generator,
-          mysql_adapter
-        )
+        Departure::DbClient.new(config, original_client)
       end
 
       # add_index is modified from the underlying mysql adapter implementation to ensure we add ALTER TABLE to it

--- a/lib/departure/db_client.rb
+++ b/lib/departure/db_client.rb
@@ -6,11 +6,9 @@ module Departure
   # It executes pt-online-schema-change commands in a new process and gets its
   # output and status
   class DbClient
-    extend ::Forwardable
+    delegate_missing_to :database_client
 
-    # These are methods we know will be sent to the raw_connection
-    # other methods are forwarded to the raw_connection, database_adapter or supered
-    def_delegators :raw_connection, :server_info, :execute, :escape, :close, :affected_rows, :closed?
+    attr_reader :database_client
 
     # Constructor
     #
@@ -18,28 +16,12 @@ module Departure
     # @param cli_generator [CliGenerator]
     # @param mysql_adapter [ActiveRecord::ConnectionAdapter] it must implement
     #   #execute and #raw_connection
-    def initialize(logger, cli_generator, mysql_adapter, config = Departure.configuration)
+    def initialize(logger, cli_generator, database_client, config = Departure.configuration)
       @logger = logger
       @cli_generator = cli_generator
-      @mysql_adapter = mysql_adapter
+      @database_client = database_client
       @error_log_path = config&.error_log_path
       @redirect_stderr = config&.redirect_stderr
-    end
-
-    def query_options
-      raw_connection.query_options
-    end
-
-    def abandon_results!
-      raw_connection.abandon_results!
-    end
-
-    def database_adapter
-      @mysql_adapter
-    end
-
-    def raw_connection
-      database_adapter.raw_connection
     end
 
     # Intercepts raw query calls to pass ALTER TABLE statements to pt-online-schema-change
@@ -49,43 +31,22 @@ module Departure
     # eg: sends to database adapter
     #   query("COMMIT") - query("SELECT * from 'comments'")
     def query(raw_sql_string)
-      # binding.pry if sql.include? "index"
       if alter_statement?(raw_sql_string)
-        command_line = cli_generator.parse_statement(raw_sql_string)
+        command_line = @cli_generator.parse_statement(raw_sql_string)
         send_to_pt_online_schema_change(command_line)
       else
-        database_adapter.execute(raw_sql_string)
+        database_client.query(raw_sql_string)
       end
     end
 
     # Runs raw_sql_string through pt-online-schema-change command line tool
     def send_to_pt_online_schema_change(raw_sql_string)
-      Command.new(raw_sql_string, error_log_path, logger, redirect_stderr).run
+      Command.new(raw_sql_string, @error_log_path, @logger, @redirect_stderr).run
     end
 
     private
 
-    attr_reader :logger, :cli_generator, :mysql_adapter, :error_log_path, :redirect_stderr
-
-    # This runner forwards missing methods to both the raw_connection and database adapter
-    def method_missing(method_name, *args, &block)
-      if raw_connection.respond_to?(method_name)
-        raw_connection.send(method_name, *args, &block)
-      elsif database_adapter.respond_to?(method_name)
-        database_adapter.send(method_name, *args, &block)
-      else
-        super
-      end
-    end
-
-    def respond_to_missing?(method_name, include_private = false)
-      raw_connection.respond_to?(method_name) || database_adapter.respond_to?(method_name) || super
-    end
-
     # Checks whether the sql statement is an ALTER TABLE
-    #
-    # @param sql [String]
-    # @return [Boolean]
     def alter_statement?(raw_sql_string)
       raw_sql_string =~ /\Aalter table/i
     end

--- a/lib/departure/db_client.rb
+++ b/lib/departure/db_client.rb
@@ -30,7 +30,6 @@ module Departure
     #   query("COMMIT") - query("SELECT * from 'comments'")
     def query(raw_sql_string)
       if alter_statement?(raw_sql_string)
-        command_line = @cli_generator.parse_statement(raw_sql_string)
         send_to_pt_online_schema_change(command_line)
       else
         database_client.query(raw_sql_string)
@@ -39,15 +38,14 @@ module Departure
 
     # Runs raw_sql_string through pt-online-schema-change command line tool
     def send_to_pt_online_schema_change(raw_sql_string)
-      Command.new(raw_sql_string,
+      command_line = @cli_generator.parse_statement(raw_sql_string)
+
+      Command.new(command_line,
                   Departure.configuration.error_log_path,
                   @logger,
                   Departure.configuration.redirect_stderr).run
     end
 
-    private
-
-    # Checks whether the sql statement is an ALTER TABLE
     def alter_statement?(raw_sql_string)
       raw_sql_string =~ /\Aalter table/i
     end

--- a/lib/departure/db_client.rb
+++ b/lib/departure/db_client.rb
@@ -10,7 +10,6 @@ module Departure
 
     attr_reader :database_client
 
-    # def initialize(logger, cli_generator, database_client, config = Departure.configuration)
     def initialize(config, database_client)
       @config = config
       @database_client = database_client
@@ -30,7 +29,7 @@ module Departure
     #   query("COMMIT") - query("SELECT * from 'comments'")
     def query(raw_sql_string)
       if alter_statement?(raw_sql_string)
-        send_to_pt_online_schema_change(command_line)
+        send_to_pt_online_schema_change(raw_sql_string)
       else
         database_client.query(raw_sql_string)
       end

--- a/spec/departure/db_client_spec.rb
+++ b/spec/departure/db_client_spec.rb
@@ -22,19 +22,19 @@ describe Departure::DbClient do
     let(:status) { instance_double(Process::Status) }
     let(:cmd) { instance_double(Departure::Command, run: status) }
 
-    before do
-      allow(Departure::Command)
-        .to receive(:new).with(command_line, config.error_log_path, logger, config.redirect_stderr)
-        .and_return(cmd)
-    end
+    # before do
+    #   allow(Departure::Command)
+    #     .to receive(:new).with(command_line, config.error_log_path, logger, config.redirect_stderr)
+    #     .and_return(cmd)
+    # end
 
-    it 'executes the pt-online-schema-change command' do
-      runner.send_to_pt_online_schema_change(command_line)
-      expect(cmd).to have_received(:run)
-    end
-
-    it 'returns the command status' do
-      expect(runner.send_to_pt_online_schema_change(command_line)).to eq(status)
-    end
+    # it 'executes the pt-online-schema-change command' do
+    #   runner.send_to_pt_online_schema_change(command_line)
+    #   expect(cmd).to have_received(:run)
+    # end
+    #
+    # it 'returns the command status' do
+    #   expect(runner.send_to_pt_online_schema_change(command_line)).to eq(status)
+    # end
   end
 end

--- a/spec/departure/db_client_spec.rb
+++ b/spec/departure/db_client_spec.rb
@@ -18,26 +18,6 @@ describe Departure::DbClient do
 
   let(:runner) { described_class.new(logger, cli_generator, mysql_adapter, config) }
 
-  it 'exposed the database adapter' do
-    expect(runner.database_adapter).to eql(mysql_adapter)
-  end
-
-  describe '#query' do
-  end
-
-  describe '#affected_rows' do
-    let(:mysql_client) { double(:mysql_client) }
-
-    before do
-      allow(mysql_adapter).to receive(:raw_connection).and_return(mysql_client)
-    end
-
-    it 'delegates to the MySQL adapter\'s client' do
-      expect(mysql_client).to receive(:affected_rows)
-      runner.affected_rows
-    end
-  end
-
   describe '#execute' do
     let(:status) { instance_double(Process::Status) }
     let(:cmd) { instance_double(Departure::Command, run: status) }

--- a/spec/departure/db_client_spec.rb
+++ b/spec/departure/db_client_spec.rb
@@ -2,39 +2,59 @@ require 'spec_helper'
 require 'tempfile'
 
 describe Departure::DbClient do
-  let(:command_line) { 'pt-online-schema-change command' }
-  let(:logger) { instance_double(Departure::Logger) }
-  let(:cli_generator) { instance_double(Departure::CliGenerator) }
-  let(:mysql_adapter) do
-    instance_double(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
-  end
-  let(:config) do
-    instance_double(
-      Departure::Configuration,
-      error_log_path: 'departure_error.log',
-      redirect_stderr: true
-    )
+  let(:db_config) do
+    { adapter: 'percona', host: 'db', username: 'root', password: nil, database: 'departure_test', flags: 2 }
   end
 
-  let(:runner) { described_class.new(logger, cli_generator, mysql_adapter, config) }
+  let(:database_client) { instance_double(::Mysql2::Client) }
 
-  describe '#execute' do
+  let(:cmd) { instance_double(Departure::Command, run: status) }
+  let(:status) { instance_double(Process::Status) }
+
+  let(:instance) { described_class.new(db_config, database_client) }
+
+  let(:alter_db_statement) { 'ALTER TABLE comments ADD `some_identifier` INT(11) DEFAULT NULL;' }
+  let(:commit_db_statement) { 'commit;' }
+
+  describe 'send_to_pt_online_schema_change' do
+    it 'parses and sends to the command object' do
+      expect(Departure::Command)
+        .to receive(:new).with(instance_of(String), Departure.configuration.error_log_path,
+                               instance_of(Departure::NullLogger), Departure.configuration.redirect_stderr)
+        .and_return(cmd)
+      expect(cmd).to receive(:run)
+
+      instance.send_to_pt_online_schema_change(alter_db_statement)
+    end
+  end
+
+  describe 'alter_statement?' do
+    it 'true when begins with alter table' do
+      expect(instance.alter_statement?(alter_db_statement)).to be_truthy
+    end
+
+    it 'false when does not begin with alter table statement' do
+      expect(instance.alter_statement?(commit_db_statement)).to be_falsey
+    end
+  end
+
+  describe '#query' do
     let(:status) { instance_double(Process::Status) }
-    let(:cmd) { instance_double(Departure::Command, run: status) }
 
-    # before do
-    #   allow(Departure::Command)
-    #     .to receive(:new).with(command_line, config.error_log_path, logger, config.redirect_stderr)
-    #     .and_return(cmd)
-    # end
+    it 'delegates to the database_client when we do not have an alter statement' do
+      expect(database_client).to receive(:query).with(commit_db_statement)
 
-    # it 'executes the pt-online-schema-change command' do
-    #   runner.send_to_pt_online_schema_change(command_line)
-    #   expect(cmd).to have_received(:run)
-    # end
-    #
-    # it 'returns the command status' do
-    #   expect(runner.send_to_pt_online_schema_change(command_line)).to eq(status)
-    # end
+      instance.query(commit_db_statement)
+    end
+
+    it 'runs alter statements through departure command' do
+      expect(Departure::Command)
+        .to receive(:new).with(instance_of(String), Departure.configuration.error_log_path,
+                               instance_of(Departure::NullLogger), Departure.configuration.redirect_stderr)
+                         .and_return(cmd)
+      expect(cmd).to receive(:run)
+
+      instance.query(alter_db_statement)
+    end
   end
 end

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -44,6 +44,7 @@ describe Departure, integration: true do
 
     it 'when foreign key has default name' do
       ActiveRecord::Base.connection.add_foreign_key(:comments, :products)
+      expect(:comments).to have_foreign_key_on('product_id')
 
       ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
@@ -51,6 +52,7 @@ describe Departure, integration: true do
 
     it 'when foreign key has a custom name' do
       ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "fk_123456")
+      expect(:comments).to have_foreign_key_on('product_id')
 
       ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
@@ -58,6 +60,7 @@ describe Departure, integration: true do
 
     it 'when foreign key has a custom name prefixed with _' do
       ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "_fk_123456")
+      expect(:comments).to have_foreign_key_on('product_id')
 
       ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')
@@ -65,6 +68,7 @@ describe Departure, integration: true do
 
     it 'when foreign key has a custom name prefixed with __ (double _)' do
       ActiveRecord::Base.connection.add_foreign_key(:comments, :products, name: "__fk_123456")
+      expect(:comments).to have_foreign_key_on('product_id')
 
       ActiveRecord::MigrationContext.new(migration_paths, ActiveRecord::SchemaMigration).run(direction, version)
       expect(:comments).not_to have_foreign_key_on('product_id')


### PR DESCRIPTION
Moving RailsAdapter to be a very skinny wrapper around the existing database client. 
 - Update adapter#new_client to initialize a Departure::DbClient and pass in the super'ed built new_client to delegate to
 - Update Departure::DbClient to strictly pass alter statements to the percona command line, otherwise send to underlying client.  Expose query, alter_statement? and send_to_pt_online_schema_change methods
 - Update adapter#query to delegate alter statements to send_to_pt_online_schema_change, otherwise super to the existing mysql2 adapter 
