### PR TITLE
Remove stderr message "Including for_alter statements"

### DIFF
--- a/lib/active_record/connection_adapters/for_alter.rb
+++ b/lib/active_record/connection_adapters/for_alter.rb
@@ -1,12 +1,6 @@
 require 'active_record/connection_adapters/mysql/schema_statements'
 
 module ForAlterStatements
-  class << self
-    def included(_)
-      STDERR.puts 'Including for_alter statements'
-    end
-  end
-
   def bulk_change_table(table_name, operations) #:nodoc:
     sqls = operations.flat_map do |command, args|
       table = args.shift


### PR DESCRIPTION
I'm getting the message just by requiring the gem

```
$ irb
irb(main):001> gem 'departure', '7.0.0'
=> true
irb(main):002> require 'departure'
Including for_alter statements
=> true
```

This is especially problematic in rake tasks in production where we check for real errors in STDERR.

I would suggest to just remove the message completely.