### PR TITLE
Prepare release 8.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [NEXT]
 
+## [8.0.2] - 2026-04-30
+
+- [Fix Rails multi-database migrations](https://github.com/departurerb/departure/pull/138)
+
 ## [8.0.1] - 2025-12-12
 
 - [Remove stderr message "Including for_alter statements"](https://github.com/departurerb/departure/pull/136)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    departure (8.0.1)
+    departure (8.0.2)
       activerecord (>= 7.2.0)
       mysql2 (>= 0.4.0, < 0.6.0)
       railties (>= 7.2.0)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    departure (8.0.1)
+    departure (8.0.2)
       activerecord (>= 7.2.0)
       mysql2 (>= 0.4.0, < 0.6.0)
       railties (>= 7.2.0)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    departure (8.0.1)
+    departure (8.0.2)
       activerecord (>= 7.2.0)
       mysql2 (>= 0.4.0, < 0.6.0)
       railties (>= 7.2.0)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    departure (8.0.1)
+    departure (8.0.2)
       activerecord (>= 7.2.0)
       mysql2 (>= 0.4.0, < 0.6.0)
       railties (>= 7.2.0)

--- a/lib/departure/version.rb
+++ b/lib/departure/version.rb
@@ -1,3 +1,3 @@
 module Departure
-  VERSION = '8.0.1'.freeze
+  VERSION = '8.0.2'.freeze
 end


### PR DESCRIPTION
## Summary

- Bump Departure to `8.0.2`.
- Add the `8.0.2` changelog entry for the Rails multi-database migration fix from #138.
- Refresh the main and appraisal lockfiles so they point at `departure (8.0.2)`.

## Verification

- `bundle exec rubocop --parallel --cache false`
- `bundle exec rspec --tag '~integration'`
- `bundle exec rake build`

Full integration coverage should run in GitHub Actions, where MySQL and Percona Toolkit are provisioned by CI.
