### PR TITLE
Prepare release 8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Please follow the format in [Keep a Changelog](http://keepachangelog.com/)
 
 ## [NEXT]
 
+## [8.1.0] - 2026-05-28
+
+- [Add Rails 8.1 Trilogy adapter support](https://github.com/departurerb/departure/pull/132)
+
 ## [8.0.2] - 2026-04-30
 
 - [Fix Rails multi-database migrations](https://github.com/departurerb/departure/pull/138)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    departure (8.0.2)
+    departure (8.1.0)
       activerecord (>= 7.2.0)
       mysql2 (>= 0.4.0, < 0.6.0)
       railties (>= 7.2.0)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    departure (8.0.2)
+    departure (8.1.0)
       activerecord (>= 7.2.0)
       mysql2 (>= 0.4.0, < 0.6.0)
       railties (>= 7.2.0)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    departure (8.0.2)
+    departure (8.1.0)
       activerecord (>= 7.2.0)
       mysql2 (>= 0.4.0, < 0.6.0)
       railties (>= 7.2.0)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    departure (8.0.2)
+    departure (8.1.0)
       activerecord (>= 7.2.0)
       mysql2 (>= 0.4.0, < 0.6.0)
       railties (>= 7.2.0)

--- a/lib/departure/version.rb
+++ b/lib/departure/version.rb
@@ -1,3 +1,3 @@
 module Departure
-  VERSION = '8.0.2'.freeze
+  VERSION = '8.1.0'.freeze
 end


### PR DESCRIPTION
## Summary

- Bump Departure to `8.1.0`.
- Add the `8.1.0` changelog entry for Rails 8.1 Trilogy adapter support from #132.
- Refresh the main and appraisal lockfiles so they point at `departure (8.1.0)`.

## Verification

- `docker compose exec rails bundle exec appraisal rails-8-1 bundle exec rubocop --parallel`
- `docker compose exec rails bundle exec appraisal rails-8-1 bundle exec rspec --tag '~integration'`
- `docker compose exec rails bundle exec rake build`

Full integration coverage should run in GitHub Actions, where MySQL and Percona Toolkit are provisioned by CI.